### PR TITLE
/users/meエンドポイントの404エラーを修正

### DIFF
--- a/back/app/main.py
+++ b/back/app/main.py
@@ -41,3 +41,4 @@ async def root():
 app.include_router(auth_router)
 app.include_router(diary_router)
 app.include_router(friend_router)
+app.include_router(user_router)


### PR DESCRIPTION
## 概要

ログイン成功後に、バックエンドのターミナルで`/users/me`エンドポイントに対する404 Not Foundエラーが毎回発生していた問題を修正しました。

## やったこと

### 問題の原因
`main.py`（あるいはアプリケーションのエントリーポイント）において、ユーザー関連のルーティングを担当する`user_router`が、メインの`app`インスタンスに登録されていませんでした。
これにより、アプリケーションが`/users/`から始まるパスを認識できず、404エラーを返していました。

### 修正内容
`app.include_router(user_router)`の1行を追記し、`user_router`を`app`に正しく登録しました。
これにより、`/users/me`などのエンドポイントへのリクエストが、意図通りにルーティングされるようになります。

## 動作確認

レビュワーの方が現象と修正を確認するための手順です。

1. このブランチをローカルで起動します。
2. フロントエンドから、正しいIDとパスワードでログイン処理を行います。
3. ログインが成功し、フロントエンドが正常にトップページなどに遷移することを確認します。
4. **バックエンドのターミナル出力を確認し、以前発生していた `404 Not Found` のエラーログが表示されなくなったことを確認します。**