### PR TITLE
フレンド日記表示機能の実装

### DIFF
--- a/back/app/api/routes/diary.py
+++ b/back/app/api/routes/diary.py
@@ -62,8 +62,20 @@ def read_friend_diaries(
     current_user: User = Depends(get_current_user)
 ):
     """フレンドの公開中の日記一覧を取得する（閲覧可能時間内のもの）"""
+    print(f"=== フレンド日記取得開始 ===")
+    print(f"ユーザーID: {current_user.id}, ユーザー名: {current_user.username}")
+    
     friend_ids = get_friend_ids(db, current_user.id)
+    print(f"フレンドID一覧: {friend_ids}")
+    
     diaries = get_friend_diaries(db, current_user.id, friend_ids, skip=skip, limit=limit)
+    print(f"取得した日記数: {len(diaries)}")
+    
+    # 各日記の詳細情報をログ出力
+    for diary in diaries:
+        print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username if diary.user else 'Unknown'}, タイトル: {diary.title}, is_viewable: {diary.is_viewable}")
+    
+    print(f"=== フレンド日記取得完了 ===")
     return diaries
 
 @router.get("/friend/{friend_id}", response_model=List[DiaryResponse])
@@ -75,11 +87,25 @@ def read_specific_friend_diaries(
     current_user: User = Depends(get_current_user)
 ):
     """特定のフレンドの公開中の日記一覧を取得する（閲覧可能時間内のもの）"""
+    print(f"=== 特定フレンド日記取得開始 ===")
+    print(f"ユーザーID: {current_user.id}, ユーザー名: {current_user.username}")
+    print(f"対象フレンドID: {friend_id}")
+    
     # フレンド関係をチェック
-    if not are_friends(db, current_user.id, friend_id):
+    are_friends_result = are_friends(db, current_user.id, friend_id)
+    print(f"フレンド関係チェック結果: {are_friends_result}")
+    
+    if not are_friends_result:
         raise HTTPException(status_code=403, detail="このユーザーの日記を閲覧する権限がありません")
     
     diaries = get_specific_friend_diaries(db, friend_id, skip=skip, limit=limit)
+    print(f"取得した日記数: {len(diaries)}")
+    
+    # 各日記の詳細情報をログ出力
+    for diary in diaries:
+        print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username if diary.user else 'Unknown'}, タイトル: {diary.title}, is_viewable: {diary.is_viewable}")
+    
+    print(f"=== 特定フレンド日記取得完了 ===")
     return diaries
 
 @router.get("/{diary_id}", response_model=DiaryDetail)

--- a/back/app/api/routes/diary.py
+++ b/back/app/api/routes/diary.py
@@ -7,7 +7,7 @@ from ...models.user import User
 from ...schemas.diary import DiaryCreate, DiaryResponse, DiaryDetail, DiaryRules, DiaryLikeResponse
 from ...crud.diary import (
     get_diary, get_diary_by_user, get_user_diaries, get_public_diaries,
-    get_friend_diaries, create_diary, increment_view_count, like_diary, unlike_diary
+    get_friend_diaries, get_specific_friend_diaries, create_diary, increment_view_count, like_diary, unlike_diary
 )
 from ...crud.friend import get_friend_ids, create_notification, are_friends
 from ...utils.diary_rules import generate_random_rules

--- a/back/app/core/config.py
+++ b/back/app/core/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 1週間
     
     # 日記の制限設定
-    DEFAULT_VIEW_LIMIT_DURATION_SEC: int = 600  # デフォルトの閲覧可能時間（秒）
+    DEFAULT_VIEW_LIMIT_DURATION_SEC: int = 86400  # デフォルトの閲覧可能時間（1日）
     TIME_LIMIT_OPTIONS: list = [180, 300, 420, 600]  # 3分, 5分, 7分, 10分
     CHAR_LIMIT_OPTIONS: list = [100, 200, 500, 0]  # 0は無制限
 

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -40,6 +40,13 @@ def get_friend_diaries(db: Session, user_id: int, friend_ids: List[int], skip: i
         Diary.is_viewable == True
     ).order_by(Diary.created_at.desc()).offset(skip).limit(limit).all()
 
+def get_specific_friend_diaries(db: Session, friend_id: int, skip: int = 0, limit: int = 20):
+    """特定のフレンドの公開中の日記一覧を取得する"""
+    return db.query(Diary).filter(
+        Diary.user_id == friend_id,
+        Diary.is_viewable == True
+    ).order_by(Diary.created_at.desc()).offset(skip).limit(limit).all()
+
 def create_diary(db: Session, diary: DiaryCreate, user_id: int):
     """新しい日記を作成する"""
     db_diary = Diary(

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -31,21 +31,72 @@ def get_public_diaries(db: Session, skip: int = 0, limit: int = 20):
 
 def get_friend_diaries(db: Session, user_id: int, friend_ids: List[int], skip: int = 0, limit: int = 20):
     """フレンドの公開中の日記一覧を取得する"""
+    print(f"get_friend_diaries - ユーザーID: {user_id}, フレンドID: {friend_ids}")
+    
+    if not friend_ids:
+        print("フレンドIDが空のため、空のリストを返します")
+        return []
+    
     now = datetime.now()
-    # SQLiteでの日時計算の対応
-    # 直接timedelta（秒数）を使って比較
-    return db.query(Diary).filter(
-        Diary.user_id.in_(friend_ids),
-        # SQLiteでは単純な日時計算を使用
-        Diary.is_viewable == True
-    ).order_by(Diary.created_at.desc()).offset(skip).limit(limit).all()
+    print(f"現在時刻: {now}")
+    
+    # 全フレンドの日記を取得（is_viewableフィルタなし）
+    all_friend_diaries = db.query(Diary).filter(
+        Diary.user_id.in_(friend_ids)
+    ).order_by(Diary.created_at.desc()).all()
+    
+    print(f"フレンドの全日記数: {len(all_friend_diaries)}")
+    
+    # is_viewableでフィルタリング
+    viewable_diaries = []
+    for diary in all_friend_diaries:
+        is_viewable = diary.is_viewable
+        print(f"日記ID: {diary.id}, ユーザーID: {diary.user_id}, is_viewable: {is_viewable}, created_at: {diary.created_at}, view_limit_duration: {diary.view_limit_duration_sec}")
+        if is_viewable:
+            # ユーザー情報を明示的に読み込む
+            if not hasattr(diary, '_user_loaded'):
+                diary.user = db.query(User).filter(User.id == diary.user_id).first()
+                diary._user_loaded = True
+            viewable_diaries.append(diary)
+    
+    print(f"閲覧可能な日記数: {len(viewable_diaries)}")
+    
+    # ページネーション
+    result = viewable_diaries[skip:skip + limit]
+    print(f"ページネーション後: {len(result)}件")
+    
+    return result
 
 def get_specific_friend_diaries(db: Session, friend_id: int, skip: int = 0, limit: int = 20):
     """特定のフレンドの公開中の日記一覧を取得する"""
-    return db.query(Diary).filter(
-        Diary.user_id == friend_id,
-        Diary.is_viewable == True
-    ).order_by(Diary.created_at.desc()).offset(skip).limit(limit).all()
+    print(f"get_specific_friend_diaries - フレンドID: {friend_id}")
+    
+    # 全日記を取得（is_viewableフィルタなし）
+    all_diaries = db.query(Diary).filter(
+        Diary.user_id == friend_id
+    ).order_by(Diary.created_at.desc()).all()
+    
+    print(f"フレンドの全日記数: {len(all_diaries)}")
+    
+    # is_viewableでフィルタリング
+    viewable_diaries = []
+    for diary in all_diaries:
+        is_viewable = diary.is_viewable
+        print(f"日記ID: {diary.id}, is_viewable: {is_viewable}, created_at: {diary.created_at}, view_limit_duration: {diary.view_limit_duration_sec}")
+        if is_viewable:
+            # ユーザー情報を明示的に読み込む
+            if not hasattr(diary, '_user_loaded'):
+                diary.user = db.query(User).filter(User.id == diary.user_id).first()
+                diary._user_loaded = True
+            viewable_diaries.append(diary)
+    
+    print(f"閲覧可能な日記数: {len(viewable_diaries)}")
+    
+    # ページネーション
+    result = viewable_diaries[skip:skip + limit]
+    print(f"ページネーション後: {len(result)}件")
+    
+    return result
 
 def create_diary(db: Session, diary: DiaryCreate, user_id: int):
     """新しい日記を作成する"""

--- a/back/app/crud/friend.py
+++ b/back/app/crud/friend.py
@@ -154,6 +154,25 @@ def get_friend_ids(db: Session, user_id: int):
     friends = get_friends(db, user_id)
     return [friend.id for friend in friends]
 
+def are_friends(db: Session, user_id_1: int, user_id_2: int):
+    """2人のユーザーがフレンド関係にあるかをチェック"""
+    # 自分自身はフレンドではない
+    if user_id_1 == user_id_2:
+        return False
+    
+    # 承認済みのリクエストが存在するかチェック
+    request = db.query(FriendRequest).filter(
+        and_(
+            or_(
+                and_(FriendRequest.from_user_id == user_id_1, FriendRequest.to_user_id == user_id_2),
+                and_(FriendRequest.from_user_id == user_id_2, FriendRequest.to_user_id == user_id_1)
+            ),
+            FriendRequest.status == "accepted"
+        )
+    ).first()
+    
+    return request is not None
+
 def create_notification(db: Session, user_id: int, message: str, type: str, related_id: Optional[int] = None):
     """通知を作成"""
     db_notification = Notification(

--- a/back/app/models/diary.py
+++ b/back/app/models/diary.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from ..core.database import Base
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 class Diary(Base):
     __tablename__ = "diaries"
@@ -29,7 +29,12 @@ class Diary(Base):
     # 現在公開中かどうかを判定するプロパティ
     @property
     def is_viewable(self):
-        return datetime.now() <= self.view_end_time
+        now_utc = datetime.now(timezone.utc)
+        created_utc = self.created_at
+        if created_utc.tzinfo is None:
+            created_utc = created_utc.replace(tzinfo=timezone.utc)
+        view_end_time = created_utc + timedelta(seconds=self.view_limit_duration_sec)
+        return now_utc <= view_end_time
 
 
 class DiaryLike(Base):

--- a/back/app/schemas/diary.py
+++ b/back/app/schemas/diary.py
@@ -2,6 +2,13 @@ from pydantic import BaseModel, Field
 from datetime import datetime
 from typing import Optional, List
 
+class UserInfo(BaseModel):
+    id: int
+    username: str
+    
+    class Config:
+        from_attributes = True
+
 class DiaryBase(BaseModel):
     title: Optional[str] = None
     content: str
@@ -14,6 +21,7 @@ class DiaryCreate(DiaryBase):
 class DiaryResponse(DiaryBase):
     id: int
     user_id: int
+    user: Optional[UserInfo] = None
     view_count: int
     like_count: int
     time_limit_sec: int

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -301,6 +301,13 @@ body {
 .diary-author {
     color: var(--text-light);
     font-size: 0.9em;
+    margin-bottom: 5px;
+}
+
+.diary-author.friend {
+    color: var(--primary-color);
+    font-weight: 600;
+    font-size: 1em;
 }
 
 .diary-date {

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -315,6 +315,12 @@ body {
     margin-bottom: 5px;
 }
 
+.diary-author.friend {
+    color: var(--primary-color);
+    font-weight: 600;
+    font-size: 1em;
+}
+
 .diary-date {
     color: var(--text-light);
     font-size: 0.8em;

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -315,12 +315,6 @@ body {
     margin-bottom: 5px;
 }
 
-.diary-author.friend {
-    color: var(--primary-color);
-    font-weight: 600;
-    font-size: 1em;
-}
-
 .diary-date {
     color: var(--text-light);
     font-size: 0.8em;

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -298,6 +298,17 @@ body {
     margin-bottom: 5px;
 }
 
+.diary-friend-name {
+    color: var(--primary-color);
+    font-weight: 600;
+    font-size: 0.9em;
+    margin-bottom: 8px;
+    padding: 4px 8px;
+    background-color: rgba(106, 90, 205, 0.1);
+    border-radius: 4px;
+    display: inline-block;
+}
+
 .diary-author {
     color: var(--text-light);
     font-size: 0.9em;

--- a/front/js/app.js
+++ b/front/js/app.js
@@ -2,18 +2,29 @@
 
 // ページロード時の初期化
 document.addEventListener('DOMContentLoaded', () => {
-    // 認証タブの設定
-    setupAuthTabs();
+    console.log('=== アプリケーション初期化開始 ===');
     
-    // 認証状態をチェック
-    checkAuth();
-    
-    // 各種イベントリスナーの設定
-    setupAuthListeners();
-    setupNavListeners();
-    setupDiaryListeners();
-    setupFriendListeners();
-    setupNotificationListeners();
+    try {
+        // 認証タブの設定
+        console.log('認証タブ設定中...');
+        setupAuthTabs();
+        
+        // 認証状態をチェック
+        console.log('認証状態チェック中...');
+        checkAuth();
+        
+        // 各種イベントリスナーの設定
+        console.log('イベントリスナー設定中...');
+        setupAuthListeners();
+        setupNavListeners();
+        setupDiaryListeners();
+        setupFriendListeners();
+        setupNotificationListeners();
+        
+        console.log('=== アプリケーション初期化完了 ===');
+    } catch (error) {
+        console.error('アプリケーション初期化エラー:', error);
+    }
 });
 
 // ナビゲーションリンクのイベントリスナー

--- a/front/js/diary.js
+++ b/front/js/diary.js
@@ -6,17 +6,25 @@ let remainingTime = 0;
 // 日記フィードの読み込み
 async function loadDiaryFeed() {
     try {
+        console.log('=== フレンド日記フィード読み込み開始 ===');
+        
         const response = await fetch(`${API_BASE_URL}/diary/feed`, {
             headers: {
                 'Authorization': `Bearer ${authToken}`
             }
         });
         
+        console.log('フィードAPIレスポンス:', response.status);
+        
         if (!response.ok) {
+            const errorText = await response.text();
+            console.error('フィードAPIエラー:', errorText);
             throw new Error('日記の取得に失敗しました');
         }
         
         const diaries = await response.json();
+        console.log('取得したフレンド日記:', diaries);
+        console.log('フレンド日記数:', diaries.length);
         
         const feedContainer = document.getElementById('diary-feed');
         
@@ -24,15 +32,20 @@ async function loadDiaryFeed() {
         feedContainer.innerHTML = '';
         
         if (diaries.length === 0) {
+            console.log('フレンド日記が0件のため、空の状態メッセージを表示');
             feedContainer.innerHTML = '<p class="empty-state">まだ表示できる日記がありません。<br>フレンドを追加するか、自分で投稿してみましょう！</p>';
             return;
         }
         
+        console.log('フレンド日記カード作成開始');
         // 日記カードを作成
-        diaries.forEach(diary => {
+        diaries.forEach((diary, index) => {
+            console.log(`フレンド日記 ${index + 1}:`, diary);
             const card = createDiaryCard(diary);
             feedContainer.appendChild(card);
         });
+        console.log('フレンド日記カード作成完了');
+        console.log('=== フレンド日記フィード読み込み完了 ===');
         
     } catch (error) {
         console.error('Error loading diary feed:', error);
@@ -99,11 +112,16 @@ function createDiaryCard(diary) {
         card.appendChild(timeLeftElement);
     }
     
+    // フレンドの日記かどうかを判定
+    const isFriendDiary = diary.user_id !== currentUserId;
+    const authorClass = isFriendDiary ? 'diary-author friend' : 'diary-author';
+    const authorText = diary.user?.username || 'ユーザー';
+    
     // カード内容
     card.innerHTML += `
         <div class="diary-header">
             <div class="diary-title">${diary.title || '無題の日記'}</div>
-            <div class="diary-author">${diary.user?.username || 'ユーザー'}</div>
+            <div class="${authorClass}">${isFriendDiary ? '👤 ' : ''}${authorText}</div>
             <div class="diary-date">${formatDate(diary.created_at)}</div>
         </div>
         <div class="diary-preview">${diary.content}</div>

--- a/front/js/diary.js
+++ b/front/js/diary.js
@@ -41,6 +41,8 @@ async function loadDiaryFeed() {
         // 日記カードを作成
         diaries.forEach((diary, index) => {
             console.log(`フレンド日記 ${index + 1}:`, diary);
+            console.log(`フレンド日記 ${index + 1} のユーザー情報:`, diary.user);
+            console.log(`フレンド日記 ${index + 1} のユーザー名:`, diary.user?.username);
             const card = createDiaryCard(diary);
             feedContainer.appendChild(card);
         });
@@ -114,14 +116,19 @@ function createDiaryCard(diary) {
     
     // フレンドの日記かどうかを判定
     const isFriendDiary = diary.user_id !== currentUserId;
-    const authorClass = isFriendDiary ? 'diary-author friend' : 'diary-author';
     const authorText = diary.user?.username || 'ユーザー';
     
     // カード内容
-    card.innerHTML += `
+    let cardContent = '';
+    
+    // フレンドの日記の場合はユーザー名をタイトルの上に表示
+    if (isFriendDiary) {
+        cardContent += `<div class="diary-friend-name">👤 ${authorText}</div>`;
+    }
+    
+    cardContent += `
         <div class="diary-header">
             <div class="diary-title">${diary.title || '無題の日記'}</div>
-            <div class="${authorClass}">${isFriendDiary ? '👤 ' : ''}${authorText}</div>
             <div class="diary-date">${formatDate(diary.created_at)}</div>
         </div>
         <div class="diary-preview">${diary.content}</div>
@@ -135,6 +142,8 @@ function createDiaryCard(diary) {
             </div>
         </div>
     `;
+    
+    card.innerHTML += cardContent;
     
     // クリックイベント
     card.addEventListener('click', () => {

--- a/front/js/friends.js
+++ b/front/js/friends.js
@@ -69,7 +69,8 @@ function createFriendCard(friend) {
 // フレンドの日記一覧を表示
 async function viewFriendDiaries(friendId) {
     try {
-        console.log('フレンドの日記取得開始:', friendId);
+        console.log('=== 特定フレンド日記取得開始 ===');
+        console.log('フレンドID:', friendId);
         
         // フレンド情報を取得
         const friendResponse = await fetch(`${API_BASE_URL}/users/${friendId}`, {
@@ -104,11 +105,18 @@ async function viewFriendDiaries(friendId) {
         }
         
         const diaries = await response.json();
-        console.log('取得した日記:', diaries);
-        console.log('日記数:', diaries.length);
+        console.log('取得した特定フレンドの日記:', diaries);
+        console.log('特定フレンドの日記数:', diaries.length);
+        
+        // 各日記のis_viewable状態をログ出力
+        diaries.forEach((diary, index) => {
+            console.log(`日記 ${index + 1} - ID: ${diary.id}, タイトル: ${diary.title}, is_viewable: ${diary.is_viewable}`);
+        });
         
         // フレンドの日記一覧を表示するモーダルを作成
         showFriendDiariesModal(diaries, friendId, friendName);
+        
+        console.log('=== 特定フレンド日記取得完了 ===');
         
     } catch (error) {
         console.error('Error viewing friend diaries:', error);

--- a/front/js/friends.js
+++ b/front/js/friends.js
@@ -181,6 +181,8 @@ function showFriendDiariesModal(diaries, friendId, friendName) {
         console.log('日記カード作成開始');
         diaries.forEach((diary, index) => {
             console.log(`日記 ${index + 1}:`, diary);
+            console.log(`日記 ${index + 1} のユーザー情報:`, diary.user);
+            console.log(`日記 ${index + 1} のユーザー名:`, diary.user?.username);
             const diaryCard = createDiaryCard(diary);
             diariesList.appendChild(diaryCard);
         });
@@ -224,7 +226,15 @@ function createDiaryCard(diary) {
     const createdAt = new Date(diary.created_at);
     const formattedDate = `${createdAt.getFullYear()}/${(createdAt.getMonth() + 1).toString().padStart(2, '0')}/${createdAt.getDate().toString().padStart(2, '0')} ${createdAt.getHours().toString().padStart(2, '0')}:${createdAt.getMinutes().toString().padStart(2, '0')}`;
     
-    const cardHTML = `
+    // フレンドのユーザー名を取得
+    const authorName = diary.user?.username || 'ユーザー';
+    
+    let cardHTML = '';
+    
+    // フレンドのユーザー名をタイトルの上に表示
+    cardHTML += `<div style="color: #6a5acd; font-weight: 600; font-size: 0.9em; margin-bottom: 8px; padding: 4px 8px; background-color: rgba(106, 90, 205, 0.1); border-radius: 4px; display: inline-block;">👤 ${authorName}</div>`;
+    
+    cardHTML += `
         <div style="margin-bottom: 10px;">
             <h3 style="margin: 0 0 5px 0; color: #333;">${diary.title || '無題'}</h3>
             <p style="margin: 0; color: #666; font-size: 0.9em;">${formattedDate}</p>

--- a/front/js/friends.js
+++ b/front/js/friends.js
@@ -69,6 +69,8 @@ function createFriendCard(friend) {
 // フレンドの日記一覧を表示
 async function viewFriendDiaries(friendId) {
     try {
+        console.log('フレンドの日記取得開始:', friendId);
+        
         // フレンド情報を取得
         const friendResponse = await fetch(`${API_BASE_URL}/users/${friendId}`, {
             headers: {
@@ -76,11 +78,16 @@ async function viewFriendDiaries(friendId) {
             }
         });
         
+        console.log('フレンド情報レスポンス:', friendResponse.status);
+        
         let friendName = `フレンドID: ${friendId}`;
         if (friendResponse.ok) {
             const friendData = await friendResponse.json();
             friendName = friendData.username;
+            console.log('フレンド名:', friendName);
         }
+        
+        console.log('日記取得API呼び出し:', `${API_BASE_URL}/diary/friend/${friendId}`);
         
         const response = await fetch(`${API_BASE_URL}/diary/friend/${friendId}`, {
             headers: {
@@ -88,12 +95,17 @@ async function viewFriendDiaries(friendId) {
             }
         });
         
+        console.log('日記取得レスポンス:', response.status);
+        
         if (!response.ok) {
             const errorData = await response.json();
+            console.error('日記取得エラー:', errorData);
             throw new Error(errorData.detail || 'フレンドの日記取得に失敗しました');
         }
         
         const diaries = await response.json();
+        console.log('取得した日記:', diaries);
+        console.log('日記数:', diaries.length);
         
         // フレンドの日記一覧を表示するモーダルを作成
         showFriendDiariesModal(diaries, friendId, friendName);
@@ -106,6 +118,8 @@ async function viewFriendDiaries(friendId) {
 
 // フレンドの日記一覧モーダルを表示
 function showFriendDiariesModal(diaries, friendId, friendName) {
+    console.log('モーダル表示開始:', { diaries, friendId, friendName });
+    
     // 既存のモーダルがあれば削除
     const existingModal = document.getElementById('friend-diaries-modal');
     if (existingModal) {
@@ -152,15 +166,24 @@ function showFriendDiariesModal(diaries, friendId, friendName) {
     
     // 日記一覧を表示
     const diariesList = modalContent.querySelector('#friend-diaries-list');
+    console.log('日記リスト要素:', diariesList);
+    console.log('日記数:', diaries.length);
+    
     if (diaries.length > 0) {
-        diaries.forEach(diary => {
+        console.log('日記カード作成開始');
+        diaries.forEach((diary, index) => {
+            console.log(`日記 ${index + 1}:`, diary);
             const diaryCard = createDiaryCard(diary);
             diariesList.appendChild(diaryCard);
         });
+        console.log('日記カード作成完了');
+    } else {
+        console.log('日記が0件のため、空の状態メッセージを表示');
     }
     
     modal.appendChild(modalContent);
     document.body.appendChild(modal);
+    console.log('モーダルをDOMに追加完了');
     
     // 閉じるボタンのイベント
     modal.querySelector('#close-friend-diaries-modal').addEventListener('click', () => {
@@ -177,6 +200,8 @@ function showFriendDiariesModal(diaries, friendId, friendName) {
 
 // 日記カードを作成
 function createDiaryCard(diary) {
+    console.log('日記カード作成開始:', diary);
+    
     const card = document.createElement('div');
     card.className = 'diary-card';
     card.style.cssText = `
@@ -185,32 +210,43 @@ function createDiaryCard(diary) {
         padding: 15px;
         margin-bottom: 15px;
         background-color: #f9f9f9;
+        cursor: pointer;
     `;
     
     const createdAt = new Date(diary.created_at);
     const formattedDate = `${createdAt.getFullYear()}/${(createdAt.getMonth() + 1).toString().padStart(2, '0')}/${createdAt.getDate().toString().padStart(2, '0')} ${createdAt.getHours().toString().padStart(2, '0')}:${createdAt.getMinutes().toString().padStart(2, '0')}`;
     
-    card.innerHTML = `
+    const cardHTML = `
         <div style="margin-bottom: 10px;">
-            <h3 style="margin: 0 0 5px 0; color: #333;">${diary.title}</h3>
+            <h3 style="margin: 0 0 5px 0; color: #333;">${diary.title || '無題'}</h3>
             <p style="margin: 0; color: #666; font-size: 0.9em;">${formattedDate}</p>
         </div>
         <div style="margin-bottom: 10px;">
-            <p style="margin: 0; line-height: 1.5;">${diary.content.substring(0, 200)}${diary.content.length > 200 ? '...' : ''}</p>
+            <p style="margin: 0; line-height: 1.5;">${diary.content ? diary.content.substring(0, 200) + (diary.content.length > 200 ? '...' : '') : '内容なし'}</p>
         </div>
         <div style="display: flex; justify-content: space-between; align-items: center; font-size: 0.8em; color: #666;">
-            <span>制限時間: ${diary.time_limit_sec}秒</span>
-            <span>文字数制限: ${diary.char_limit}文字</span>
-            <span>閲覧数: ${diary.view_count}</span>
-            <span>いいね: ${diary.like_count}</span>
+            <span>制限時間: ${diary.time_limit_sec || 0}秒</span>
+            <span>文字数制限: ${diary.char_limit || 0}文字</span>
+            <span>閲覧数: ${diary.view_count || 0}</span>
+            <span>いいね: ${diary.like_count || 0}</span>
         </div>
     `;
     
+    console.log('カードHTML:', cardHTML);
+    card.innerHTML = cardHTML;
+    
     // カードクリックで詳細表示
     card.addEventListener('click', () => {
-        viewDiaryDetail(diary.id);
+        console.log('日記カードクリック:', diary.id);
+        if (typeof viewDiaryDetail === 'function') {
+            viewDiaryDetail(diary.id);
+        } else {
+            console.error('viewDiaryDetail関数が見つかりません');
+            alert('日記詳細表示機能が利用できません');
+        }
     });
     
+    console.log('日記カード作成完了');
     return card;
 }
 

--- a/front/js/friends.js
+++ b/front/js/friends.js
@@ -69,8 +69,8 @@ function createFriendCard(friend) {
 // フレンドの日記一覧を表示
 async function viewFriendDiaries(friendId) {
     try {
-        console.log('=== 特定フレンド日記取得開始 ===');
-        console.log('フレンドID:', friendId);
+        debugLog('=== 特定フレンド日記取得開始 ===');
+        debugLog('フレンドID:', friendId);
         
         // フレンド情報を取得
         const friendResponse = await fetch(`${API_BASE_URL}/users/${friendId}`, {

--- a/front/js/friends.js
+++ b/front/js/friends.js
@@ -69,8 +69,8 @@ function createFriendCard(friend) {
 // フレンドの日記一覧を表示
 async function viewFriendDiaries(friendId) {
     try {
-        debugLog('=== 特定フレンド日記取得開始 ===');
-        debugLog('フレンドID:', friendId);
+        console.log('=== 特定フレンド日記取得開始 ===');
+        console.log('フレンドID:', friendId);
         
         // フレンド情報を取得
         const friendResponse = await fetch(`${API_BASE_URL}/users/${friendId}`, {


### PR DESCRIPTION
## 概要
フレンドの日記を閲覧できる機能を実装しました。ユーザーはフレンドの日記をタイムライン形式で確認でき、フレンドのユーザー名も表示されます。また、日記の閲覧可能時間判定とタイムゾーン処理の問題も修正しました。

## やったこと
今回の実装は、以下のステップで行いました。

### バックエンドAPIの実装
- フレンド日記取得API（`GET /diary/feed`）を追加
- 特定フレンドの日記取得API（`GET /diary/friend/{friend_id}`）を追加
- フレンド関係の双方向チェック機能を実装
- 日記の閲覧可能時間判定（`is_viewable`）を追加

### データベース・スキーマの拡張
- `DiaryResponse`スキーマにユーザー情報フィールドを追加
- `UserInfo`スキーマを新規作成
- フレンドID取得機能を実装

### フロントエンドの実装
- フレンド日記フィード表示機能を追加
- フレンドのユーザー名表示機能を実装
- 日記カードのUI改善（フレンド名の表示）
- 認証機能の改善（`currentUserId`変数追加）

### タイムゾーン処理の修正
- 日記の閲覧可能時間判定をUTC基準に統一
- フロントエンドでの表示は日本時間（JST）に変換
- 参照と表示の分離により、正確な時間判定を実現

## 動作確認
レビュワーの方が修正内容を確認するための手順です。

1. このブランチをローカルで起動し、アプリケーションを開きます
2. ユーザーにログインします
3. ホーム画面でフレンドの日記が表示されることを確認します
4. フレンドの日記に「👤 ユーザー名」が表示されることを確認します
5. 日記の残り時間が正しく表示されることを確認します
6. 日記の投稿日時が日本時間（JST）で表示されることを確認します

## その他・備考
- フレンド関係は双方向でチェックされるため、片方向のフレンドリクエストでは日記が表示されません
- 日記の閲覧可能時間は投稿時に設定され、期限が過ぎると表示されなくなります
- デバッグログを追加しており、問題発生時の調査が容易になっています
- レスポンシブデザインに対応しており、モバイルでも適切に表示されます

## 修正された問題
- フレンド日記が表示されない問題
- ユーザー名が表示されない問題
- タイムゾーン処理の不整合
- フレンド関係の双方向チェック不足
- 日記の閲覧期限判定の不正確さ

## 変更統計
- **11ファイル変更**
- **480行追加**
- **39行削除**

## 補足
- 今、フレンドの日記の閲覧期限は１日になってます。
