### PR TITLE
自分の日記の削除機能実装

### DIFF
--- a/back/app/api/routes/diary.py
+++ b/back/app/api/routes/diary.py
@@ -7,7 +7,7 @@ from ...models.user import User
 from ...schemas.diary import DiaryCreate, DiaryResponse, DiaryDetail, DiaryRules, DiaryLikeResponse
 from ...crud.diary import (
     get_diary, get_diary_by_user, get_user_diaries, get_public_diaries,
-    get_friend_diaries, get_specific_friend_diaries, create_diary, increment_view_count, like_diary, unlike_diary
+    get_friend_diaries, get_specific_friend_diaries, create_diary, increment_view_count, like_diary, unlike_diary, delete_diary
 )
 from ...crud.friend import get_friend_ids, create_notification, are_friends
 from ...utils.diary_rules import generate_random_rules
@@ -191,6 +191,17 @@ def unlike_diary_endpoint(
     result = unlike_diary(db, diary_id, current_user.id)
     if not result:
         raise HTTPException(status_code=404, detail="いいねが見つかりません")
+
+@router.delete("/{diary_id}", status_code=204)
+def delete_diary_endpoint(
+    diary_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """日記を削除する（自分の日記のみ）"""
+    result = delete_diary(db, diary_id, current_user.id)
+    if not result:
+        raise HTTPException(status_code=404, detail="日記が見つからないか、削除権限がありません")
 
 @router.post("/{diary_id}/feedback", summary="日記のフィードバックを生成")
 async def create_diary_feedback(

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -179,3 +179,17 @@ def unlike_diary(db: Session, diary_id: int, user_id: int):
     
     db.commit()
     return True
+
+def delete_diary(db: Session, diary_id: int, user_id: int):
+    """日記を削除する（自分の日記のみ）"""
+    diary = get_diary_by_user(db, user_id, diary_id)
+    if not diary:
+        return False
+    
+    # 関連するいいねも削除
+    db.query(DiaryLike).filter(DiaryLike.diary_id == diary_id).delete()
+    
+    # 日記を削除
+    db.delete(diary)
+    db.commit()
+    return True

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import and_, or_, func
 from datetime import datetime, timedelta
 from typing import List, Optional
-from ..models.diary import Diary, DiaryLike
+from ..models.diary import Diary, DiaryLike, Feedback
 from ..models.user import User
 from ..schemas.diary import DiaryCreate
 from .user import update_streak
@@ -185,6 +185,9 @@ def delete_diary(db: Session, diary_id: int, user_id: int):
     diary = get_diary_by_user(db, user_id, diary_id)
     if not diary:
         return False
+    
+    # 関連するフィードバックも削除
+    db.query(Feedback).filter(Feedback.diary_id == diary_id).delete()
     
     # 関連するいいねも削除
     db.query(DiaryLike).filter(DiaryLike.diary_id == diary_id).delete()

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -87,6 +87,15 @@ body {
     color: #e74c3c;
 }
 
+.danger-btn {
+    background-color: var(--error-color);
+    color: white;
+}
+
+.danger-btn:hover {
+    background-color: #c82333;
+}
+
 /* フォームスタイル */
 .form-group {
     margin-bottom: 15px;
@@ -694,6 +703,13 @@ body {
 
 .diary-detail-content {
     margin-bottom: 30px;
+}
+
+.diary-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    align-items: center;
 }
 
 #detail-title {

--- a/front/index.html
+++ b/front/index.html
@@ -218,7 +218,10 @@
                         <span class="rule-small">制限時間: <span id="detail-time-limit"></span></span>
                         <span class="rule-small">文字数制限: <span id="detail-char-limit"></span></span>
                     </div>
-                    <button id="like-btn" class="btn like-btn"><i class="far fa-heart"></i> いいね</button>
+                    <div class="diary-actions">
+                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i class="fas fa-trash"></i> 削除</button>
+                        <button id="like-btn" class="btn like-btn"><i class="far fa-heart"></i> いいね</button>
+                    </div>
                 </div>
             </div>
 

--- a/front/index.html
+++ b/front/index.html
@@ -219,7 +219,7 @@
                         <span class="rule-small">文字数制限: <span id="detail-char-limit"></span></span>
                     </div>
                     <div class="diary-actions">
-                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i class="fas fa-trash"></i> 削除</button>
+                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i class="fas fa-trash"></i></button>
                         <button id="like-btn" class="btn like-btn"><i class="far fa-heart"></i> いいね</button>
                     </div>
                 </div>

--- a/front/js/diary.js
+++ b/front/js/diary.js
@@ -277,6 +277,15 @@ async function viewDiaryDetail(diaryId) {
         document.getElementById('detail-time-limit').textContent = formatTime(diary.time_limit_sec);
         document.getElementById('detail-char-limit').textContent = diary.char_limit === 0 ? '無制限' : `${diary.char_limit}文字`;
 
+        // 自分の日記の場合のみ削除ボタンを表示
+        const deleteBtn = document.getElementById('delete-diary-btn');
+        if (diary.user_id === currentUser.id) {
+            deleteBtn.classList.remove('hidden');
+            deleteBtn.setAttribute('data-id', diary.id);
+        } else {
+            deleteBtn.classList.add('hidden');
+        }
+
         // フィードバックセクションの初期化
         initFeedbackSection(diaryId, diary.user_id);
         
@@ -422,6 +431,43 @@ function displayFeedback(content) {
     document.getElementById('get-feedback-btn').classList.add('hidden');
 }
 
+// 日記を削除する
+async function deleteDiary(diaryId) {
+    // 確認ダイアログを表示
+    if (!confirm('この日記を削除しますか？\nこの操作は取り消せません。')) {
+        return;
+    }
+    
+    try {
+        const response = await fetch(`${API_BASE_URL}/diary/${diaryId}`, {
+            method: 'DELETE',
+            headers: {
+                'Authorization': `Bearer ${authToken}`
+            }
+        });
+        
+        if (!response.ok) {
+            throw new Error('日記の削除に失敗しました');
+        }
+        
+        // 削除成功のメッセージを表示
+        alert('日記を削除しました');
+        
+        // 詳細画面を閉じて自分の日記一覧に戻る
+        document.getElementById('diary-detail-screen').classList.add('hidden');
+        document.getElementById('main-screen').classList.remove('hidden');
+        
+        // 自分の日記一覧を表示
+        document.getElementById('nav-my-diaries').click();
+        
+        // 日記一覧を再読み込み
+        loadMyDiaries();
+        
+    } catch (error) {
+        console.error('Error deleting diary:', error);
+        alert('日記の削除に失敗しました: ' + error.message);
+    }
+}
 
 // 新しい日記を書く
 async function startNewDiary() {
@@ -647,6 +693,12 @@ function setupDiaryListeners() {
     document.getElementById('get-feedback-btn').addEventListener('click', () => {
         const diaryId = document.getElementById('get-feedback-btn').getAttribute('data-id');
         requestFeedback(diaryId);
+    });
+    
+    // 削除ボタン
+    document.getElementById('delete-diary-btn').addEventListener('click', () => {
+        const diaryId = document.getElementById('delete-diary-btn').getAttribute('data-id');
+        deleteDiary(diaryId);
     });
     
     // 文字数カウンター


### PR DESCRIPTION
# 日記削除機能の実装

## 概要
自分の日記を削除できる機能を追加。削除ボタンはいいねボタンの左側に配置し、削除前に確認ダイアログを表示。

## 実装内容

### バックエンド
- **CRUD関数追加**: `delete_diary()` - 自分の日記のみ削除可能
- **APIエンドポイント追加**: `DELETE /diary/{diary_id}` - 削除権限チェック付き

### フロントエンド
- **HTML**: 削除ボタンを日記詳細画面のフッターに配置
- **CSS**: 赤いゴミ箱アイコンのスタイル追加
- **JavaScript**: 削除機能と確認ダイアログの実装

## 機能仕様
- **表示条件**: 自分の日記のみ削除ボタン表示
- **削除プロセス**: ボタンクリック → 確認ダイアログ → 削除実行 → 一覧更新
- **セキュリティ**: 自分の日記のみ削除可能、確認ダイアログで誤操作防止

## テスト項目
- [x] 自分の日記で削除ボタン表示
- [x] 他人の日記で削除ボタン非表示
- [x] 確認ダイアログ表示
- [x] 削除成功時の画面遷移
- [x] エラーハンドリング