### PR TITLE
月ごとのフィードバック機能実装

### DIFF
--- a/back/app/api/routes/diary.py
+++ b/back/app/api/routes/diary.py
@@ -7,7 +7,7 @@ from ...models.user import User
 from ...schemas.diary import DiaryCreate, DiaryResponse, DiaryDetail, DiaryRules, DiaryLikeResponse
 from ...crud.diary import (
     get_diary, get_diary_by_user, get_user_diaries, get_public_diaries,
-    get_friend_diaries, get_specific_friend_diaries, create_diary, increment_view_count, like_diary, unlike_diary
+    get_friend_diaries, get_specific_friend_diaries, create_diary, increment_view_count, like_diary, unlike_diary, delete_diary
 )
 from ...crud.friend import get_friend_ids, create_notification, are_friends
 from ...utils.diary_rules import generate_random_rules
@@ -191,6 +191,17 @@ def unlike_diary_endpoint(
     result = unlike_diary(db, diary_id, current_user.id)
     if not result:
         raise HTTPException(status_code=404, detail="いいねが見つかりません")
+
+@router.delete("/{diary_id}", status_code=204)
+def delete_diary_endpoint(
+    diary_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """日記を削除する（自分の日記のみ）"""
+    result = delete_diary(db, diary_id, current_user.id)
+    if not result:
+        raise HTTPException(status_code=404, detail="日記が見つからないか、削除権限がありません")
 
 @router.post("/{diary_id}/feedback", summary="日記のフィードバックを生成")
 async def create_diary_feedback(

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -196,3 +196,11 @@ def delete_diary(db: Session, diary_id: int, user_id: int):
     db.delete(diary)
     db.commit()
     return True
+
+def get_user_diaries_by_period(db: Session, user_id: int, start_date: datetime, end_date: datetime):
+    """指定された期間のユーザーの日記を取得する"""
+    return db.query(Diary).filter(
+        Diary.user_id == user_id,
+        Diary.created_at >= start_date,
+        Diary.created_at < end_date
+    ).order_by(Diary.created_at.asc()).all()

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -179,3 +179,17 @@ def unlike_diary(db: Session, diary_id: int, user_id: int):
     
     db.commit()
     return True
+
+def delete_diary(db: Session, diary_id: int, user_id: int):
+    """日記を削除する（自分の日記のみ）"""
+    diary = get_diary_by_user(db, user_id, diary_id)
+    if not diary:
+        return False
+    
+    # 関連するいいねも削除
+    db.query(DiaryLike).filter(DiaryLike.diary_id == diary_id).delete()
+    
+    # 日記を削除
+    db.delete(diary)
+    db.commit()
+    return True

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import and_, or_, func
 from datetime import datetime, timedelta
 from typing import List, Optional
-from ..models.diary import Diary, DiaryLike
+from ..models.diary import Diary, DiaryLike, Feedback
 from ..models.user import User
 from ..schemas.diary import DiaryCreate
 from .user import update_streak
@@ -185,6 +185,9 @@ def delete_diary(db: Session, diary_id: int, user_id: int):
     diary = get_diary_by_user(db, user_id, diary_id)
     if not diary:
         return False
+    
+    # 関連するフィードバックも削除
+    db.query(Feedback).filter(Feedback.diary_id == diary_id).delete()
     
     # 関連するいいねも削除
     db.query(DiaryLike).filter(DiaryLike.diary_id == diary_id).delete()

--- a/back/app/models/diary.py
+++ b/back/app/models/diary.py
@@ -67,8 +67,9 @@ class DiaryLike(Base):
 class Feedback(Base):
     __tablename__ = "feedbacks"
     id = Column(Integer, primary_key=True, index=True)
-    diary_id = Column(Integer, ForeignKey("diaries.id"), unique=True)
+    diary_id = Column(Integer, ForeignKey("diaries.id"), nullable=True)  # 月ごとフィードバックではnull
     user_id = Column(Integer, ForeignKey("users.id"))
+    period = Column(String, nullable=True)  # 月ごとフィードバック用 (例: "2024-06")
     content = Column(Text, nullable=False)
     created_at = Column(DateTime, default=func.now())
 

--- a/back/app/services/gemini_service.py
+++ b/back/app/services/gemini_service.py
@@ -27,3 +27,35 @@ def generate_feedback_from_diary(diary_content: str) -> str:
     except Exception as e:
         print(f"Gemini API Error: {e}")
         return "フィードバックの生成中にエラーが発生しました。"
+
+def generate_monthly_feedback_from_diaries(diaries_content: str, year: int, month: int) -> str:
+    """
+    月の日記を全て読み込んで、月ごとのフィードバックを生成する
+    """
+    if not diaries_content:
+        return f"{year}年{month}月の日記が見つかりませんでした。"
+
+    # プロンプトの設計
+    prompt = f"""
+    あなたは、ユーザーに寄り添う優しいカウンセラーです。
+    以下の{year}年{month}月の日記を全て読んで、その月の全体を通しての振り返りとフィードバックを300字以内で作成してください。
+    
+    フィードバックは以下の点を含めてください：
+    1. その月の全体的な印象やテーマ
+    2. 書いた人の心境の変化や成長
+    3. 特に印象的な出来事や感情
+    4. 来月への前向きなメッセージ
+    
+    フィードバックは、丁寧な言葉遣いで、友人のように語りかけるスタイルでお願いします。
+    「この1ヶ月、お疲れさまでした」のような温かい言葉で始めてください。
+
+    # {year}年{month}月の日記内容
+    {diaries_content}
+    """
+
+    try:
+        response = model.generate_content(prompt)
+        return response.text
+    except Exception as e:
+        print(f"Gemini API Error: {e}")
+        return f"{year}年{month}月のフィードバックの生成中にエラーが発生しました。"

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -87,6 +87,15 @@ body {
     color: #e74c3c;
 }
 
+.danger-btn {
+    background-color: var(--error-color);
+    color: white;
+}
+
+.danger-btn:hover {
+    background-color: #c82333;
+}
+
 /* フォームスタイル */
 .form-group {
     margin-bottom: 15px;
@@ -694,6 +703,13 @@ body {
 
 .diary-detail-content {
     margin-bottom: 30px;
+}
+
+.diary-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    align-items: center;
 }
 
 #detail-title {

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -783,6 +783,22 @@ body {
     margin-top: 10px;
 }
 
+/* 月ごとのフィードバックセクション */
+.monthly-feedback-section {
+    margin-top: 20px;
+    text-align: center;
+    padding: 20px;
+    background-color: #f8f9fa;
+    border-radius: 10px;
+    border: 1px solid #e9ecef;
+}
+
+.monthly-feedback-section .feedback-container {
+    margin-top: 15px;
+    background-color: #fff3cd; /* 明るい黄色系の背景色 */
+    border-left: 4px solid #ffc107; /* 黄色のアクセントボーダー */
+}
+
 /* レスポンシブデザイン */
 @media (max-width: 768px) {
     .diary-feed {

--- a/front/index.html
+++ b/front/index.html
@@ -218,7 +218,10 @@
                         <span class="rule-small">制限時間: <span id="detail-time-limit"></span></span>
                         <span class="rule-small">文字数制限: <span id="detail-char-limit"></span></span>
                     </div>
-                    <button id="like-btn" class="btn like-btn"><i class="far fa-heart"></i> いいね</button>
+                    <div class="diary-actions">
+                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i class="fas fa-trash"></i> 削除</button>
+                        <button id="like-btn" class="btn like-btn"><i class="far fa-heart"></i> いいね</button>
+                    </div>
                 </div>
             </div>
 

--- a/front/index.html
+++ b/front/index.html
@@ -105,6 +105,20 @@
                         <div class="calendar-grid" id="calendar-grid">
                             <!-- カレンダーはJSで動的に生成 -->
                         </div>
+                        
+                        <!-- 月ごとのフィードバック機能 -->
+                        <div id="monthly-feedback-section" class="monthly-feedback-section">
+                            <div id="monthly-feedback-container" class="feedback-container hidden">
+                                <h4>今月の振り返り</h4>
+                                <p id="monthly-feedback-content"></p>
+                            </div>
+                            <button id="get-monthly-feedback-btn" class="btn btn-secondary">
+                                <i class="fas fa-calendar-alt"></i> 今月の振り返りをもらう
+                            </button>
+                            <p id="monthly-feedback-loading-state" class="feedback-loading hidden">
+                                月ごとフィードバックを生成中です...
+                            </p>
+                        </div>
                     </div>
 
                     <div id="my-diary-list" class="diary-list">

--- a/front/index.html
+++ b/front/index.html
@@ -219,7 +219,7 @@
                         <span class="rule-small">文字数制限: <span id="detail-char-limit"></span></span>
                     </div>
                     <div class="diary-actions">
-                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i class="fas fa-trash"></i> 削除</button>
+                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i class="fas fa-trash"></i></button>
                         <button id="like-btn" class="btn like-btn"><i class="far fa-heart"></i> いいね</button>
                     </div>
                 </div>

--- a/front/js/diary.js
+++ b/front/js/diary.js
@@ -277,6 +277,15 @@ async function viewDiaryDetail(diaryId) {
         document.getElementById('detail-time-limit').textContent = formatTime(diary.time_limit_sec);
         document.getElementById('detail-char-limit').textContent = diary.char_limit === 0 ? '無制限' : `${diary.char_limit}文字`;
 
+        // 自分の日記の場合のみ削除ボタンを表示
+        const deleteBtn = document.getElementById('delete-diary-btn');
+        if (diary.user_id === currentUser.id) {
+            deleteBtn.classList.remove('hidden');
+            deleteBtn.setAttribute('data-id', diary.id);
+        } else {
+            deleteBtn.classList.add('hidden');
+        }
+
         // フィードバックセクションの初期化
         initFeedbackSection(diaryId, diary.user_id);
         
@@ -422,6 +431,43 @@ function displayFeedback(content) {
     document.getElementById('get-feedback-btn').classList.add('hidden');
 }
 
+// 日記を削除する
+async function deleteDiary(diaryId) {
+    // 確認ダイアログを表示
+    if (!confirm('この日記を削除しますか？\nこの操作は取り消せません。')) {
+        return;
+    }
+    
+    try {
+        const response = await fetch(`${API_BASE_URL}/diary/${diaryId}`, {
+            method: 'DELETE',
+            headers: {
+                'Authorization': `Bearer ${authToken}`
+            }
+        });
+        
+        if (!response.ok) {
+            throw new Error('日記の削除に失敗しました');
+        }
+        
+        // 削除成功のメッセージを表示
+        alert('日記を削除しました');
+        
+        // 詳細画面を閉じて自分の日記一覧に戻る
+        document.getElementById('diary-detail-screen').classList.add('hidden');
+        document.getElementById('main-screen').classList.remove('hidden');
+        
+        // 自分の日記一覧を表示
+        document.getElementById('nav-my-diaries').click();
+        
+        // 日記一覧を再読み込み
+        loadMyDiaries();
+        
+    } catch (error) {
+        console.error('Error deleting diary:', error);
+        alert('日記の削除に失敗しました: ' + error.message);
+    }
+}
 
 // 新しい日記を書く
 async function startNewDiary() {
@@ -647,6 +693,12 @@ function setupDiaryListeners() {
     document.getElementById('get-feedback-btn').addEventListener('click', () => {
         const diaryId = document.getElementById('get-feedback-btn').getAttribute('data-id');
         requestFeedback(diaryId);
+    });
+    
+    // 削除ボタン
+    document.getElementById('delete-diary-btn').addEventListener('click', () => {
+        const diaryId = document.getElementById('delete-diary-btn').getAttribute('data-id');
+        deleteDiary(diaryId);
     });
     
     // 文字数カウンター


### PR DESCRIPTION
# 月ごとのフィードバック機能追加

## 概要
日記ごとのフィードバック機能に加えて、月ごとの振り返りフィードバック機能を追加しました。ユーザーは指定した月の日記を全て読み込んで、その月全体の振り返りをAIから受け取ることができます。

## 実装内容

### バックエンド

#### 1. データベースモデルの更新
- **ファイル**: `back/app/models/diary.py`
- **変更内容**:
  - `Feedback`モデルに`period`フィールドを追加（月ごとフィードバック用）
  - `diary_id`フィールドを`nullable=True`に変更（月ごとフィードバックでは`null`）

```python
class Feedback(Base):
    __tablename__ = "feedbacks"
    id = Column(Integer, primary_key=True, index=True)
    diary_id = Column(Integer, ForeignKey("diaries.id"), nullable=True)  # 月ごとフィードバックではnull
    user_id = Column(Integer, ForeignKey("users.id"))
    period = Column(String, nullable=True)  # 月ごとフィードバック用 (例: "2024-06")
    content = Column(Text, nullable=False)
    created_at = Column(DateTime, default=func.now())
```

#### 2. APIエンドポイントの追加
- **ファイル**: `back/app/api/routes/diary.py`
- **追加エンドポイント**:
  - `POST /diary/monthly-feedback/{year}/{month}` - 月ごとのフィードバック生成
  - `GET /diary/monthly-feedback/{year}/{month}` - 月ごとのフィードバック取得

#### 3. CRUD関数の追加
- **ファイル**: `back/app/crud/diary.py`
- **追加関数**:
  - `get_user_diaries_by_period()` - 指定期間の日記を取得

#### 4. Geminiサービスの拡張
- **ファイル**: `back/app/services/gemini_service.py`
- **追加関数**:
  - `generate_monthly_feedback_from_diaries()` - 月の日記を全て読み込んでフィードバック生成

### フロントエンド

#### 1. UIの追加
- **ファイル**: `front/index.html`
- **追加内容**:
  - 自分の日記一覧画面に「今月の振り返りをもらう」ボタンを追加
  - 月ごとのフィードバック表示エリアを追加

#### 2. JavaScript機能の追加
- **ファイル**: `front/js/diary.js`
- **追加機能**:
  - `requestMonthlyFeedback()` - 月ごとのフィードバック生成リクエスト
  - `pollForMonthlyFeedback()` - フィードバック生成完了までポーリング
  - `displayMonthlyFeedback()` - 月ごとフィードバックの表示
  - `initMonthlyFeedbackSection()` - 月ごとフィードバックセクションの初期化

#### 3. スタイリングの追加
- **ファイル**: `front/css/styles.css`
- **追加スタイル**:
  - 月ごとのフィードバック用の専用スタイル
  - 黄色系の背景色で日記フィードバックと区別

## セットアップ手順

### 1. データベースの再作成
既存のデータベースを削除して新しいスキーマで再作成します：

```bash
cd back
rm diary_app.db
source ../.venv/bin/activate
python -c "from app.core.database import engine; from app.models.diary import Base; Base.metadata.create_all(bind=engine)"
```

### 2. サーバーの起動
```bash
cd back
source ../.venv/bin/activate
uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
```

### 3. フロントエンドの起動
```bash
cd front
# ブラウザでindex.htmlを開く
```

## 使用方法

1. **自分の日記一覧画面**に移動
2. カレンダーの下にある「今月の振り返りをもらう」ボタンをクリック
3. AIがその月の日記を全て読み込んで、月全体の振り返りを生成
4. 生成されたフィードバックが表示される

## フィードバックの内容

月ごとのフィードバックでは以下の内容が含まれます：
- その月の全体的な印象やテーマ
- 書いた人の心境の変化や成長
- 特に印象的な出来事や感情
- 来月への前向きなメッセージ

## 技術的な詳細

### データベース設計
- 月ごとのフィードバックは`diary_id`が`null`で`period`フィールドに年月（例: "2024-06"）を保存
- 日記ごとのフィードバックは従来通り`diary_id`に日記IDを保存

### API設計
- バックグラウンドタスクを使用してフィードバック生成（Gemini APIの応答時間を考慮）
- ポーリング機能でフィードバック生成完了まで待機

### エラーハンドリング
- 指定月に日記がない場合のエラー処理
- 既存フィードバックがある場合の重複防止
- タイムアウト処理（30秒で最大10回試行）

## 注意事項
- データベースを再作成するため、既存のデータは全て削除されます
- 新しいユーザー登録と日記投稿が必要になります
- Gemini APIキーが設定されている必要があります
