### PR TITLE
自分の日記一覧の空メッセージ修正＆ホームに自分の日記も表示

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -90,7 +90,7 @@
                         <!-- 日記カードはJSで動的に生成 -->
                         <p class="empty-state">まだ表示できる日記がありません。<br>フレンドを追加するか、自分で投稿してみましょう！</p>
                     </div>
-                    
+
                     <!-- 新しい日記ボタン（画面中央下） -->
                     <button id="new-diary-btn" class="floating-add-btn">
                         <i class="fas fa-plus"></i>
@@ -112,7 +112,7 @@
                         <div class="calendar-grid" id="calendar-grid">
                             <!-- カレンダーはJSで動的に生成 -->
                         </div>
-                        
+
                         <!-- 月ごとのフィードバック機能 -->
                         <div id="monthly-feedback-section" class="monthly-feedback-section">
                             <div id="monthly-feedback-container" class="feedback-container hidden">
@@ -130,7 +130,7 @@
 
                     <div id="my-diary-list" class="diary-list">
                         <!-- 日記リストはJSで動的に生成 -->
-                        <p class="empty-state">まだ日記を書いていません。<br>右上の「新しい日記」ボタンから投稿してみましょう！</p>
+                        <p class="empty-state">まだ日記を書いていません。<br>ホームに移動して日記を投稿してみましょう！</p>
                     </div>
                 </div>
 
@@ -240,7 +240,8 @@
                         <span class="rule-small">文字数制限: <span id="detail-char-limit"></span></span>
                     </div>
                     <div class="diary-actions">
-                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i class="fas fa-trash"></i></button>
+                        <button id="delete-diary-btn" class="btn danger-btn hidden"><i
+                                class="fas fa-trash"></i></button>
                         <button id="like-btn" class="btn like-btn"><i class="far fa-heart"></i> いいね</button>
                     </div>
                 </div>

--- a/front/js/diary.js
+++ b/front/js/diary.js
@@ -7,49 +7,47 @@ let currentCalendarDate = new Date();
 // 日記フィードの読み込み
 async function loadDiaryFeed() {
     try {
-        console.log('=== フレンド日記フィード読み込み開始 ===');
-        
-        const response = await fetch(`${API_BASE_URL}/diary/feed`, {
-            headers: {
-                'Authorization': `Bearer ${authToken}`
-            }
+        console.log('=== フィード（自分＋フレンド）日記読み込み開始 ===');
+
+        // フレンド日記取得
+        const friendRes = await fetch(`${API_BASE_URL}/diary/feed`, {
+            headers: { 'Authorization': `Bearer ${authToken}` }
         });
-        
-        console.log('フィードAPIレスポンス:', response.status);
-        
-        if (!response.ok) {
-            const errorText = await response.text();
+        if (!friendRes.ok) {
+            const errorText = await friendRes.text();
             console.error('フィードAPIエラー:', errorText);
             throw new Error('日記の取得に失敗しました');
         }
-        
-        const diaries = await response.json();
-        console.log('取得したフレンド日記:', diaries);
-        console.log('フレンド日記数:', diaries.length);
-        
+        const friendDiaries = await friendRes.json();
+
+        // 自分の日記も取得
+        const myRes = await fetch(`${API_BASE_URL}/diary/my`, {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+        if (!myRes.ok) {
+            const errorText = await myRes.text();
+            console.error('自分日記APIエラー:', errorText);
+            throw new Error('自分の日記の取得に失敗しました');
+        }
+        const myDiaries = await myRes.json();
+
+        // フレンド＋自分の日記をまとめて投稿時間順（新しい順）でソート
+        const allDiaries = [...friendDiaries, ...myDiaries];
+        allDiaries.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
         const feedContainer = document.getElementById('diary-feed');
-        
-        // 空の状態メッセージをクリア
         feedContainer.innerHTML = '';
-        
-        if (diaries.length === 0) {
-            console.log('フレンド日記が0件のため、空の状態メッセージを表示');
+
+        if (allDiaries.length === 0) {
             feedContainer.innerHTML = '<p class="empty-state">まだ表示できる日記がありません。<br>フレンドを追加するか、自分で投稿してみましょう！</p>';
             return;
         }
-        
-        console.log('フレンド日記カード作成開始');
-        // 日記カードを作成
-        diaries.forEach((diary, index) => {
-            console.log(`フレンド日記 ${index + 1}:`, diary);
-            console.log(`フレンド日記 ${index + 1} のユーザー情報:`, diary.user);
-            console.log(`フレンド日記 ${index + 1} のユーザー名:`, diary.user?.username);
+
+        allDiaries.forEach((diary, index) => {
             const card = createDiaryCard(diary);
             feedContainer.appendChild(card);
         });
-        console.log('フレンド日記カード作成完了');
-        console.log('=== フレンド日記フィード読み込み完了 ===');
-        
+        console.log('=== フィード（自分＋フレンド）日記読み込み完了 ===');
     } catch (error) {
         console.error('Error loading diary feed:', error);
     }
@@ -63,35 +61,35 @@ async function loadMyDiaries() {
                 'Authorization': `Bearer ${authToken}`
             }
         });
-        
+
         if (!response.ok) {
             throw new Error('日記の取得に失敗しました');
         }
-        
+
         const diaries = await response.json();
-        
+
         const diaryListContainer = document.getElementById('my-diary-list');
-        
+
         // 空の状態メッセージをクリア
         diaryListContainer.innerHTML = '';
-        
+
         if (diaries.length === 0) {
-            diaryListContainer.innerHTML = '<p class="empty-state">まだ日記を書いていません。<br>右上の「新しい日記」ボタンから投稿してみましょう！</p>';
+            diaryListContainer.innerHTML = '<p class="empty-state">まだ日記を書いていません。<br>ホームに移動して日記を投稿してみましょう！</p>';
             return;
         }
-        
+
         // 日記リストアイテムを作成
         diaries.forEach(diary => {
             const listItem = createDiaryListItem(diary);
             diaryListContainer.appendChild(listItem);
         });
-        
+
         // カレンダーも更新
         updateCalendar(diaries);
-        
+
         // 月ごとのフィードバックセクションを初期化
         await initMonthlyFeedbackSection();
-        
+
     } catch (error) {
         console.error('Error loading my diaries:', error);
     }
@@ -102,13 +100,13 @@ function createDiaryCard(diary) {
     const card = document.createElement('div');
     card.className = 'diary-card';
     card.setAttribute('data-id', diary.id);
-    
+
     // 閲覧可能時間を計算
     const createdDate = new Date(diary.created_at);
     const viewEndTime = new Date(createdDate.getTime() + diary.view_limit_duration_sec * 1000);
     const now = new Date();
     const timeLeftMs = viewEndTime - now;
-    
+
     // 残り時間の表示
     if (timeLeftMs > 0) {
         const minutesLeft = Math.floor(timeLeftMs / 60000);
@@ -117,19 +115,19 @@ function createDiaryCard(diary) {
         timeLeftElement.textContent = `残り ${minutesLeft} 分`;
         card.appendChild(timeLeftElement);
     }
-    
+
     // フレンドの日記かどうかを判定
     const isFriendDiary = diary.user_id !== currentUserId;
     const authorText = diary.user?.username || 'ユーザー';
-    
+
     // カード内容
     let cardContent = '';
-    
+
     // フレンドの日記の場合はユーザー名をタイトルの上に表示
     if (isFriendDiary) {
         cardContent += `<div class="diary-friend-name">👤 ${authorText}</div>`;
     }
-    
+
     cardContent += `
         <div class="diary-header">
             <div class="diary-title">${diary.title || '無題の日記'}</div>
@@ -146,14 +144,14 @@ function createDiaryCard(diary) {
             </div>
         </div>
     `;
-    
+
     card.innerHTML += cardContent;
-    
+
     // クリックイベント
     card.addEventListener('click', () => {
         viewDiaryDetail(diary.id);
     });
-    
+
     return card;
 }
 
@@ -162,7 +160,7 @@ function createDiaryListItem(diary) {
     const listItem = document.createElement('div');
     listItem.className = 'diary-list-item';
     listItem.setAttribute('data-id', diary.id);
-    
+
     listItem.innerHTML = `
         <div class="diary-title">${diary.title || '無題の日記'}</div>
         <div class="diary-date">${formatDate(diary.created_at)}</div>
@@ -174,12 +172,12 @@ function createDiaryListItem(diary) {
             </div>
         </div>
     `;
-    
+
     // クリックイベント
     listItem.addEventListener('click', () => {
         viewDiaryDetail(diary.id);
     });
-    
+
     return listItem;
 }
 
@@ -189,13 +187,13 @@ function updateCalendar(diaries) {
     const currentMonth = currentCalendarDate.getMonth();
     const currentYear = currentCalendarDate.getFullYear();
     const now = new Date();
-    
+
     // カレンダーのタイトル更新
     document.getElementById('calendar-title').textContent = `${currentYear}年${currentMonth + 1}月`;
-    
+
     // カレンダーグリッドをクリア
     calendarGrid.innerHTML = '';
-    
+
     // 曜日ヘッダーを追加
     const daysOfWeek = ['日', '月', '火', '水', '木', '金', '土'];
     daysOfWeek.forEach(day => {
@@ -204,13 +202,13 @@ function updateCalendar(diaries) {
         dayHeader.textContent = day;
         calendarGrid.appendChild(dayHeader);
     });
-    
+
     // 月の最初の日の曜日を取得
     const firstDay = new Date(currentYear, currentMonth, 1).getDay();
-    
+
     // 月の日数を取得
     const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
-    
+
     // 日記の日付を整理
     const diaryDates = {};
     diaries.forEach(diary => {
@@ -220,30 +218,30 @@ function updateCalendar(diaries) {
             diaryDates[day] = true;
         }
     });
-    
+
     // 前月の空白セルを追加
     for (let i = 0; i < firstDay; i++) {
         const emptyCell = document.createElement('div');
         emptyCell.className = 'calendar-day empty';
         calendarGrid.appendChild(emptyCell);
     }
-    
+
     // 日付セルを追加
     for (let day = 1; day <= daysInMonth; day++) {
         const dayCell = document.createElement('div');
         dayCell.className = 'calendar-day';
         dayCell.textContent = day;
-        
+
         // 日記がある日はクラスを追加
         if (diaryDates[day]) {
             dayCell.classList.add('has-diary');
         }
-        
+
         // 今日の日付にはクラスを追加
         if (day === now.getDate() && currentMonth === now.getMonth() && currentYear === now.getFullYear()) {
             dayCell.classList.add('today');
         }
-        
+
         calendarGrid.appendChild(dayCell);
     }
 }
@@ -256,17 +254,17 @@ async function viewDiaryDetail(diaryId) {
                 'Authorization': `Bearer ${authToken}`
             }
         });
-        
+
         if (!response.ok) {
             throw new Error('日記の取得に失敗しました');
         }
-        
+
         const diary = await response.json();
-        
+
         // 詳細画面を表示
         document.getElementById('main-screen').classList.add('hidden');
         document.getElementById('diary-detail-screen').classList.remove('hidden');
-        
+
         // 詳細内容を設定
         document.getElementById('detail-title').textContent = diary.title || '無題の日記';
         document.getElementById('detail-content').textContent = diary.content;
@@ -291,7 +289,7 @@ async function viewDiaryDetail(diaryId) {
 
         // フィードバックセクションの初期化
         initFeedbackSection(diaryId, diary.user_id);
-        
+
         // 閲覧記録を残す（自分の日記でない場合）
         if (diary.user_id !== currentUser.id) {
             await fetch(`${API_BASE_URL}/diary/${diaryId}/view`, {
@@ -301,7 +299,7 @@ async function viewDiaryDetail(diaryId) {
                 }
             });
         }
-        
+
     } catch (error) {
         console.error('Error viewing diary detail:', error);
     }
@@ -348,7 +346,7 @@ async function fetchAndDisplayFeedback(diaryId) {
             if (feedback && feedback.content) {
                 displayFeedback(feedback.content);
             }
-        } 
+        }
     } catch (error) {
         // 既存フィードバックがない場合はボタンが表示されたままになるので、ここではエラーログのみ
         console.error('Error fetching existing feedback:', error);
@@ -428,7 +426,7 @@ function pollForFeedback(diaryId) {
 function displayFeedback(content) {
     const feedbackContainer = document.getElementById('feedback-container');
     const feedbackContent = document.getElementById('feedback-content');
-    
+
     feedbackContent.textContent = content;
     feedbackContainer.classList.remove('hidden');
     document.getElementById('get-feedback-btn').classList.add('hidden');
@@ -507,7 +505,7 @@ function pollForMonthlyFeedback(year, month) {
 function displayMonthlyFeedback(content) {
     const monthlyFeedbackContainer = document.getElementById('monthly-feedback-container');
     const monthlyFeedbackContent = document.getElementById('monthly-feedback-content');
-    
+
     monthlyFeedbackContent.textContent = content;
     monthlyFeedbackContainer.classList.remove('hidden');
     document.getElementById('get-monthly-feedback-btn').classList.add('hidden');
@@ -527,7 +525,7 @@ async function fetchAndDisplayMonthlyFeedback(year, month) {
             if (feedback && feedback.content) {
                 displayMonthlyFeedback(feedback.content);
             }
-        } 
+        }
     } catch (error) {
         // 既存フィードバックがない場合はボタンが表示されたままになるので、ここではエラーログのみ
         console.error('Error fetching existing monthly feedback:', error);
@@ -565,7 +563,7 @@ async function deleteDiary(diaryId) {
     if (!confirm('この日記を削除しますか？\nこの操作は取り消せません。')) {
         return;
     }
-    
+
     try {
         const response = await fetch(`${API_BASE_URL}/diary/${diaryId}`, {
             method: 'DELETE',
@@ -573,24 +571,24 @@ async function deleteDiary(diaryId) {
                 'Authorization': `Bearer ${authToken}`
             }
         });
-        
+
         if (!response.ok) {
             throw new Error('日記の削除に失敗しました');
         }
-        
+
         // 削除成功のメッセージを表示
         alert('日記を削除しました');
-        
+
         // 詳細画面を閉じて自分の日記一覧に戻る
         document.getElementById('diary-detail-screen').classList.add('hidden');
         document.getElementById('main-screen').classList.remove('hidden');
-        
+
         // 自分の日記一覧を表示
         document.getElementById('nav-my-diaries').click();
-        
+
         // 日記一覧を再読み込み
         loadMyDiaries();
-        
+
     } catch (error) {
         console.error('Error deleting diary:', error);
         alert('日記の削除に失敗しました: ' + error.message);
@@ -606,22 +604,22 @@ async function startNewDiary() {
                 'Authorization': `Bearer ${authToken}`
             }
         });
-        
+
         if (!response.ok) {
             throw new Error('ルールの取得に失敗しました');
         }
-        
+
         diaryRules = await response.json();
-        
+
         // 日記作成画面を表示
         document.getElementById('main-screen').classList.add('hidden');
         document.getElementById('diary-screen').classList.remove('hidden');
-        
+
         // ルールを表示
         document.getElementById('time-limit').textContent = formatTime(diaryRules.time_limit_sec);
         document.getElementById('char-limit').textContent = diaryRules.char_limit === 0 ? '無制限' : `${diaryRules.char_limit}文字`;
         document.getElementById('max-chars').textContent = diaryRules.char_limit === 0 ? '∞' : diaryRules.char_limit;
-        
+
         // 文字数制限を設定
         const contentArea = document.getElementById('diary-content');
         if (diaryRules.char_limit > 0) {
@@ -629,15 +627,15 @@ async function startNewDiary() {
         } else {
             contentArea.removeAttribute('maxlength');
         }
-        
+
         // フォームをリセット
         document.getElementById('diary-title').value = '';
         contentArea.value = '';
         document.getElementById('char-count').textContent = '0';
-        
+
         // タイマーを開始
         startTimer(diaryRules.time_limit_sec);
-        
+
     } catch (error) {
         console.error('Error starting new diary:', error);
     }
@@ -649,14 +647,14 @@ function startTimer(seconds) {
     if (timerInterval) {
         clearInterval(timerInterval);
     }
-    
+
     remainingTime = seconds;
     updateTimerDisplay();
-    
+
     timerInterval = setInterval(() => {
         remainingTime--;
         updateTimerDisplay();
-        
+
         if (remainingTime <= 0) {
             clearInterval(timerInterval);
             // 時間切れで自動投稿
@@ -670,7 +668,7 @@ function updateTimerDisplay() {
     const minutes = Math.floor(remainingTime / 60);
     const seconds = remainingTime % 60;
     document.getElementById('timer').textContent = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-    
+
     // 残り時間が少なくなったら赤く表示
     if (remainingTime <= 30) {
         document.getElementById('timer').style.color = '#dc3545';
@@ -684,15 +682,15 @@ async function submitDiary() {
         if (timerInterval) {
             clearInterval(timerInterval);
         }
-        
+
         const title = document.getElementById('diary-title').value;
         const content = document.getElementById('diary-content').value;
-        
+
         if (!content.trim()) {
             alert('内容を入力してください');
             return;
         }
-        
+
         const response = await fetch(`${API_BASE_URL}/diary`, {
             method: 'POST',
             headers: {
@@ -707,21 +705,21 @@ async function submitDiary() {
                 view_limit_duration_sec: diaryRules.view_limit_duration_sec
             })
         });
-        
+
         if (!response.ok) {
             throw new Error('日記の投稿に失敗しました');
         }
-        
+
         // メイン画面に戻る
         document.getElementById('diary-screen').classList.add('hidden');
         document.getElementById('main-screen').classList.remove('hidden');
-        
+
         // 自分の日記一覧を更新
         await loadMyDiaries();
-        
+
         // ホーム画面のフィードも更新
         await loadDiaryFeed();
-        
+
     } catch (error) {
         console.error('Error submitting diary:', error);
         alert('日記の投稿に失敗しました: ' + error.message);
@@ -737,22 +735,22 @@ async function toggleLike(diaryId) {
                 'Authorization': `Bearer ${authToken}`
             }
         });
-        
+
         if (!response.ok) {
             throw new Error('いいねの処理に失敗しました');
         }
-        
+
         // いいねカウントを更新
         const likeCount = document.getElementById('like-count');
         const currentCount = parseInt(likeCount.textContent);
         likeCount.textContent = currentCount + 1;
-        
+
         // いいねボタンの見た目を変更
         const likeBtn = document.getElementById('like-btn');
         likeBtn.innerHTML = '<i class="fas fa-heart"></i> いいね済み';
         likeBtn.classList.add('active');
         likeBtn.disabled = true;
-        
+
     } catch (error) {
         console.error('Error toggling like:', error);
     }
@@ -761,16 +759,16 @@ async function toggleLike(diaryId) {
 // 日付のフォーマット（日本時間）
 function formatDate(dateString) {
     const date = new Date(dateString);
-    
+
     // 日本時間に変換（UTC+9）
     const jstDate = new Date(date.getTime() + (9 * 60 * 60 * 1000));
-    
+
     const year = jstDate.getFullYear();
     const month = jstDate.getMonth() + 1;
     const day = jstDate.getDate();
     const hours = jstDate.getHours().toString().padStart(2, '0');
     const minutes = jstDate.getMinutes().toString().padStart(2, '0');
-    
+
     return `${year}年${month}月${day}日 ${hours}:${minutes}`;
 }
 
@@ -787,12 +785,12 @@ function setupDiaryListeners() {
     document.getElementById('new-diary-btn').addEventListener('click', () => {
         startNewDiary();
     });
-    
+
     // 日記投稿ボタン
     document.getElementById('submit-diary-btn').addEventListener('click', () => {
         submitDiary();
     });
-    
+
     // 日記キャンセルボタン
     document.getElementById('cancel-diary-btn').addEventListener('click', () => {
         if (confirm('本当にキャンセルしますか？入力した内容は失われます。')) {
@@ -804,13 +802,13 @@ function setupDiaryListeners() {
             document.getElementById('main-screen').classList.remove('hidden');
         }
     });
-    
+
     // 詳細画面の戻るボタン
     document.getElementById('back-btn').addEventListener('click', () => {
         document.getElementById('diary-detail-screen').classList.add('hidden');
         document.getElementById('main-screen').classList.remove('hidden');
     });
-    
+
     // いいねボタン
     document.getElementById('like-btn').addEventListener('click', () => {
         const diaryId = document.getElementById('like-btn').getAttribute('data-id');
@@ -822,30 +820,30 @@ function setupDiaryListeners() {
         const diaryId = document.getElementById('get-feedback-btn').getAttribute('data-id');
         requestFeedback(diaryId);
     });
-    
+
     // 削除ボタン
     document.getElementById('delete-diary-btn').addEventListener('click', () => {
         const diaryId = document.getElementById('delete-diary-btn').getAttribute('data-id');
         deleteDiary(diaryId);
     });
-    
+
     // 文字数カウンター
     document.getElementById('diary-content').addEventListener('input', (e) => {
         document.getElementById('char-count').textContent = e.target.value.length;
     });
-    
+
     // 前の月ボタン
     document.getElementById('prev-month').addEventListener('click', () => {
         currentCalendarDate.setMonth(currentCalendarDate.getMonth() - 1);
         loadMyDiaries();
     });
-    
+
     // 次の月ボタン
     document.getElementById('next-month').addEventListener('click', () => {
         currentCalendarDate.setMonth(currentCalendarDate.getMonth() + 1);
         loadMyDiaries();
     });
-    
+
     // 月ごとフィードバック取得ボタン
     document.getElementById('get-monthly-feedback-btn').addEventListener('click', () => {
         const year = parseInt(document.getElementById('get-monthly-feedback-btn').getAttribute('data-year'));


### PR DESCRIPTION
## 概要
- 「自分の日記一覧」で日記が1件もない場合の空メッセージを  
  「まだ日記を書いていません。ホームに移動して日記を投稿してみましょう！」  
  に修正しました。
- ホーム画面のフィードに「自分の書いた日記」も表示されるようにし、フレンドの日記とまとめて投稿時間順で並ぶようにしました。

## 変更内容
- front/index.html の空メッセージ文言修正
- front/js/diary.js の `loadDiaryFeed` 関数を修正し、自分＋フレンドの日記をまとめて表示

## 動作確認
- ホーム画面で自分とフレンドの日記が時系列で表示されること
- 「自分の日記一覧」で日記がない場合、修正後のメッセージが表示されること

ご確認よろしくお願いします。