### PR TITLE
Iconを追加

### DIFF
--- a/back/app/api/routes/diary.py
+++ b/back/app/api/routes/diary.py
@@ -76,9 +76,10 @@ def read_friend_diaries(
     
     # 各日記の詳細情報をログ出力
     for diary in diaries:
-        print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username if diary.user else 'Unknown'}, タイトル: {diary.title}, is_viewable: {diary.is_viewable}")
+        print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username if diary.user else 'Unknown'}, タイトル: {diary.title}, is_viewable: {diary.is_viewable}, プロフィール画像: {diary.user.profile_image_url}")
     
     print(f"=== フレンド日記取得完了 ===")
+    print(f"diaries: {diaries}")
     return diaries
 
 @router.get("/friend/{friend_id}", response_model=List[DiaryResponse])

--- a/back/app/api/routes/user.py
+++ b/back/app/api/routes/user.py
@@ -4,8 +4,8 @@ from typing import List
 
 from ...core.database import get_db
 from ...core.security import get_current_user
-from ...schemas.user import UserResponse, UserUpdate
-from ...crud.user import get_user, update_user, delete_user, search_users
+from ...schemas.user import UserResponse, UserUpdate, ProfileImageUpdate
+from ...crud.user import get_user, update_user, delete_user, search_users, update_user_profile_image
 from ...models.user import User
 
 router = APIRouter(
@@ -39,6 +39,16 @@ def update_user_me(
 ):
     """ユーザー情報の更新"""
     updated_user = update_user(db, db_user=current_user, user_update=user_update)
+    return updated_user
+
+@router.put("/me/profile-image", response_model=UserResponse)
+def update_profile_image(
+    profile_image_update: ProfileImageUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """プロフィール画像の更新"""
+    updated_user = update_user_profile_image(db, current_user, profile_image_update.profile_image_url)
     return updated_user
 
 @router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)

--- a/back/app/crud/diary.py
+++ b/back/app/crud/diary.py
@@ -55,7 +55,7 @@ def get_friend_diaries(db: Session, user_id: int, friend_ids: List[int], skip: i
         if is_viewable:
             # ユーザー情報が読み込まれているか確認
             if diary.user:
-                print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username}, タイトル: {diary.title}, is_viewable: {is_viewable}")
+                print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username}, タイトル: {diary.title}, is_viewable: {is_viewable}, プロフィール画像: {diary.user.profile_image_url}")
             else:
                 print(f"警告: 日記ID {diary.id} のユーザー情報が取得できませんでした")
             viewable_diaries.append(diary)
@@ -87,7 +87,7 @@ def get_specific_friend_diaries(db: Session, friend_id: int, skip: int = 0, limi
         if is_viewable:
             # ユーザー情報が読み込まれているか確認
             if diary.user:
-                print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username}, タイトル: {diary.title}, is_viewable: {is_viewable}")
+                print(f"日記詳細 - ID: {diary.id}, ユーザー: {diary.user.username}, タイトル: {diary.title}, is_viewable: {is_viewable}, プロフィール画像: {diary.user.profile_image_url}")
             else:
                 print(f"警告: 日記ID {diary.id} のユーザー情報が取得できませんでした")
             viewable_diaries.append(diary)

--- a/back/app/crud/user.py
+++ b/back/app/crud/user.py
@@ -85,6 +85,8 @@ def update_user(db: Session, db_user: User, user_update):
         db_user.email = user_update.email
     if user_update.password is not None:
         db_user.hashed_password = get_password_hash(user_update.password)
+    if user_update.profile_image_url is not None:
+        db_user.profile_image_url = user_update.profile_image_url
     
     db.commit()
     db.refresh(db_user)

--- a/back/app/crud/user.py
+++ b/back/app/crud/user.py
@@ -90,6 +90,13 @@ def update_user(db: Session, db_user: User, user_update):
     db.refresh(db_user)
     return db_user
 
+def update_user_profile_image(db: Session, db_user: User, profile_image_url: str):
+    """ユーザーのプロフィール画像を更新する"""
+    db_user.profile_image_url = profile_image_url
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
 def delete_user(db: Session, user_id: int):
     """ユーザーを削除する"""
     db_user = get_user(db, user_id)

--- a/back/app/models/user.py
+++ b/back/app/models/user.py
@@ -12,6 +12,7 @@ class User(Base):
     hashed_password = Column(String)
     streak_count = Column(Integer, default=0)
     last_streak_date = Column(DateTime, default=None, nullable=True)
+    profile_image_url = Column(String, nullable=True)
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())

--- a/back/app/schemas/diary.py
+++ b/back/app/schemas/diary.py
@@ -5,6 +5,7 @@ from typing import Optional, List
 class UserInfo(BaseModel):
     id: int
     username: str
+    profile_image_url: Optional[str] = Field(None, description="Base64エンコードされた画像データまたは画像URL")
     
     class Config:
         from_attributes = True

--- a/back/app/schemas/user.py
+++ b/back/app/schemas/user.py
@@ -40,6 +40,7 @@ class UserUpdate(BaseModel):
     username: Optional[str] = None
     email: Optional[EmailStr] = None
     password: Optional[str] = None
+    profile_image_url: Optional[str] = Field(None, description="Base64エンコードされた画像データまたは画像URL")
     
     class Config:
         from_attributes = True

--- a/back/app/schemas/user.py
+++ b/back/app/schemas/user.py
@@ -16,6 +16,7 @@ class UserLogin(BaseModel):
 class UserResponse(UserBase):
     id: int
     streak_count: int
+    profile_image_url: Optional[str] = None
     created_at: datetime
     
     class Config:
@@ -23,6 +24,7 @@ class UserResponse(UserBase):
 
 class UserDetail(UserResponse):
     last_streak_date: Optional[datetime] = None
+    profile_image_url: Optional[str] = None
     
     class Config:
         from_attributes = True
@@ -38,6 +40,12 @@ class UserUpdate(BaseModel):
     username: Optional[str] = None
     email: Optional[EmailStr] = None
     password: Optional[str] = None
+    
+    class Config:
+        from_attributes = True
+
+class ProfileImageUpdate(BaseModel):
+    profile_image_url: str = Field(..., description="Base64エンコードされた画像データまたは画像URL")
     
     class Config:
         from_attributes = True

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -431,6 +431,26 @@ body {
     align-items: center;
 }
 
+/* ナビゲーションバーのプロフィール画像 */
+#nav-user-profile {
+    margin-right: 10px;
+    margin-top: 3px; /* プロフィール画像を少し下にずらす */
+}
+
+#nav-user-profile .profile-image,
+#nav-user-profile .profile-image-placeholder {
+    width: 32px;
+    height: 32px;
+    border: 2px solid var(--border-color);
+}
+
+#nav-user-profile .profile-image-placeholder {
+    background-color: var(--primary-color);
+    color: white;
+    font-size: 14px;
+    font-weight: 600;
+}
+
 #user-name {
     margin-right: 15px;
     font-weight: 600;

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -506,6 +506,46 @@ body {
     display: inline-block;
 }
 
+.diary-friend-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+    padding: 8px;
+    background-color: rgba(106, 90, 205, 0.1);
+    border-radius: 8px;
+}
+
+.diary-friend-avatar {
+    flex-shrink: 0;
+}
+
+.diary-friend-avatar .profile-image,
+.diary-friend-avatar .profile-image-placeholder {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+}
+
+.diary-friend-avatar .profile-image-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--primary-color);
+    color: white;
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.diary-friend-info .diary-friend-name {
+    margin: 0;
+    padding: 0;
+    background: none;
+    color: var(--primary-color);
+    font-weight: 600;
+    font-size: 0.9em;
+}
+
 .diary-author {
     color: var(--text-light);
     font-size: 0.9em;
@@ -1060,6 +1100,47 @@ body {
     border-radius: 50%;
     overflow: hidden;
     border: 2px solid var(--border-color);
+}
+
+/* フレンド日記モーダル内のスタイル */
+.friend-diaries-modal-content .diary-friend-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+    padding: 8px;
+    background-color: rgba(106, 90, 205, 0.1);
+    border-radius: 8px;
+}
+
+.friend-diaries-modal-content .diary-friend-avatar {
+    flex-shrink: 0;
+}
+
+.friend-diaries-modal-content .diary-friend-avatar .profile-image,
+.friend-diaries-modal-content .diary-friend-avatar .profile-image-placeholder {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+}
+
+.friend-diaries-modal-content .diary-friend-avatar .profile-image-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--primary-color);
+    color: white;
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.friend-diaries-modal-content .diary-friend-info .diary-friend-name {
+    margin: 0;
+    padding: 0;
+    background: none;
+    color: var(--primary-color);
+    font-weight: 600;
+    font-size: 0.9em;
 }
 
 /* レスポンシブデザイン */

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -108,6 +108,38 @@ body {
     font-size: 1em;
 }
 
+/* プロフィール設定フォーム */
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--text-color);
+    font-weight: 600;
+    font-size: 0.9em;
+}
+
+.form-input {
+    width: 100%;
+    padding: 10px;
+    border: 2px solid var(--border-color);
+    border-radius: 5px;
+    font-size: 1em;
+    box-sizing: border-box;
+    transition: border-color 0.3s ease;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.form-input:invalid {
+    border-color: var(--error-color);
+}
+
 /* エラーメッセージ */
 .error-message {
     color: var(--error-color);
@@ -1151,4 +1183,41 @@ body {
 
 .profile-image-upload-btn:hover {
     background-color: var(--primary-dark);
+}
+
+/* プロフィール設定フォーム */
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--text-color);
+    font-weight: 600;
+    font-size: 0.9em;
+}
+
+.form-input {
+    width: 100%;
+    padding: 10px;
+    border: 2px solid var(--border-color);
+    border-radius: 5px;
+    font-size: 1em;
+    box-sizing: border-box;
+    transition: border-color 0.3s ease;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.form-input:invalid {
+    border-color: var(--error-color);
+}
+
+/* プロフィール設定セクション間の余白 */
+.profile-settings + .profile-settings {
+    margin-top: 30px;
 }

--- a/front/css/styles.css
+++ b/front/css/styles.css
@@ -133,6 +133,127 @@ body {
     margin-left: 3px;
 }
 
+/* プロフィール画像 */
+.profile-image {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image.small {
+    width: 24px;
+    height: 24px;
+}
+
+.profile-image.large {
+    width: 80px;
+    height: 80px;
+}
+
+.profile-image-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: var(--primary-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image-placeholder.small {
+    width: 24px;
+    height: 24px;
+    font-size: 0.8em;
+}
+
+.profile-image-placeholder.large {
+    width: 80px;
+    height: 80px;
+    font-size: 1.5em;
+}
+
+/* プロフィール画像 */
+.profile-image {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image.small {
+    width: 24px;
+    height: 24px;
+}
+
+.profile-image.large {
+    width: 80px;
+    height: 80px;
+}
+
+.profile-image-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: var(--primary-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image-placeholder.small {
+    width: 24px;
+    height: 24px;
+    font-size: 0.8em;
+}
+
+.profile-image-placeholder.large {
+    width: 80px;
+    height: 80px;
+    font-size: 1.5em;
+}
+
+.profile-settings {
+    background-color: var(--card-bg);
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: var(--shadow);
+    margin-bottom: 20px;
+}
+
+.profile-image-section {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+.profile-image-input {
+    display: none;
+}
+
+.profile-image-upload-btn {
+    background-color: var(--primary-color);
+    color: white;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.9em;
+}
+
+.profile-image-upload-btn:hover {
+    background-color: var(--primary-dark);
+}
+
 /* 認証画面 */
 .auth-container {
     max-width: 400px;
@@ -183,6 +304,50 @@ body {
 
 .auth-form.active {
     display: block;
+}
+
+/* プロフィール画像 */
+.profile-image {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image.small {
+    width: 24px;
+    height: 24px;
+}
+
+.profile-image.large {
+    width: 80px;
+    height: 80px;
+}
+
+.profile-image-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: var(--primary-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image-placeholder.small {
+    width: 24px;
+    height: 24px;
+    font-size: 0.8em;
+}
+
+.profile-image-placeholder.large {
+    width: 80px;
+    height: 80px;
+    font-size: 1.5em;
 }
 
 /* ナビゲーションバー */
@@ -767,6 +932,104 @@ body {
     margin-top: 10px;
 }
 
+/* プロフィール画像とモーダル */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+.modal-content {
+    background-color: var(--card-bg);
+    border-radius: 10px;
+    padding: 0;
+    max-width: 600px;
+    max-height: 80vh;
+    width: 90%;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header h3 {
+    margin: 0;
+    color: var(--primary-color);
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: var(--text-light);
+    padding: 0;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal-close:hover {
+    color: var(--text-color);
+}
+
+.modal-body {
+    padding: 20px;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    padding: 20px;
+    border-top: 1px solid var(--border-color);
+}
+
+/* クロップ関連 */
+#crop-container {
+    max-height: 400px;
+    margin-bottom: 20px;
+}
+
+.crop-preview {
+    text-align: center;
+}
+
+.crop-preview h4 {
+    margin-bottom: 10px;
+    color: var(--text-color);
+}
+
+#crop-preview-container {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    overflow: hidden;
+    border: 2px solid var(--border-color);
+}
+
 /* レスポンシブデザイン */
 @media (max-width: 768px) {
     .diary-feed {
@@ -811,4 +1074,81 @@ body {
     .diary-rules-small {
         text-align: center;
     }
+}
+
+/* プロフィール画像 */
+.profile-image {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image.small {
+    width: 24px;
+    height: 24px;
+}
+
+.profile-image.large {
+    width: 80px;
+    height: 80px;
+}
+
+.profile-image-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: var(--primary-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    border: 2px solid var(--border-color);
+}
+
+.profile-image-placeholder.small {
+    width: 24px;
+    height: 24px;
+    font-size: 0.8em;
+}
+
+.profile-image-placeholder.large {
+    width: 80px;
+    height: 80px;
+    font-size: 1.5em;
+}
+
+.profile-settings {
+    background-color: var(--card-bg);
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: var(--shadow);
+    margin-bottom: 20px;
+}
+
+.profile-image-section {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+.profile-image-input {
+    display: none;
+}
+
+.profile-image-upload-btn {
+    background-color: var(--primary-color);
+    color: white;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.9em;
+}
+
+.profile-image-upload-btn:hover {
+    background-color: var(--primary-dark);
 }

--- a/front/index.html
+++ b/front/index.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Klee+One:wght@400;600&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Zen+Kurenaido&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.css">
 </head>
 
 <body>
@@ -67,8 +68,10 @@
                     <button id="nav-friends" class="nav-link"><i class="fas fa-user-friends"></i> フレンド</button>
                     <button id="nav-notifications" class="nav-link"><i class="fas fa-bell"></i> <span
                             id="notification-badge" class="badge hidden">0</span></button>
+                    <button id="nav-profile" class="nav-link"><i class="fas fa-user-cog"></i> プロフィール</button>
                 </div>
                 <div class="nav-user">
+                    <div id="nav-user-profile"></div>
                     <span id="user-name"></span>
                     <span id="streak-count"><i class="fas fa-fire"></i> <span id="streak-number">0</span></span>
                     <button id="logout-btn" class="btn small-btn">ログアウト</button>
@@ -157,6 +160,29 @@
                         <p class="empty-state">通知はありません。</p>
                     </div>
                 </div>
+
+                <!-- プロフィール設定画面 -->
+                <div id="profile-content" class="content hidden">
+                    <div class="content-header">
+                        <h2>プロフィール設定</h2>
+                    </div>
+
+                    <div class="profile-settings">
+                        <h3>プロフィール画像</h3>
+                        <div class="profile-image-section">
+                            <div id="current-profile-image"></div>
+                            <div>
+                                <input type="file" id="profile-image-input" class="profile-image-input" accept="image/*">
+                                <button id="profile-image-upload-btn" class="profile-image-upload-btn">
+                                    画像を選択
+                                </button>
+                                <p style="margin-top: 5px; font-size: 0.8em; color: var(--text-light);">
+                                    JPG, PNG, GIF形式に対応
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -238,12 +264,37 @@
         </div>
     </div>
 
+    <!-- 画像クロップモーダル -->
+    <div id="crop-modal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>プロフィール画像を設定</h3>
+                <button id="crop-modal-close" class="modal-close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div id="crop-container">
+                    <img id="crop-image" style="max-width: 100%;">
+                </div>
+                <div class="crop-preview">
+                    <h4>プレビュー</h4>
+                    <div id="crop-preview-container"></div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="crop-cancel-btn" class="btn secondary-btn">キャンセル</button>
+                <button id="crop-apply-btn" class="btn primary-btn">適用</button>
+            </div>
+        </div>
+    </div>
+
     <!-- JavaScript -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/auth.js"></script>
     <script src="js/diary.js"></script>
     <script src="js/friends.js"></script>
     <script src="js/notifications.js"></script>
+    <script src="js/profile.js"></script>
     <script src="js/app.js"></script>
 </body>
 

--- a/front/index.html
+++ b/front/index.html
@@ -68,7 +68,7 @@
                     <button id="nav-friends" class="nav-link"><i class="fas fa-user-friends"></i> フレンド</button>
                     <button id="nav-notifications" class="nav-link"><i class="fas fa-bell"></i> <span
                             id="notification-badge" class="badge hidden">0</span></button>
-                    <button id="nav-profile" class="nav-link"><i class="fas fa-user-cog"></i> プロフィール</button>
+                    <button id="nav-profile" class="nav-link"><i class="fas fa-user-cog"></i> 設定</button>
                 </div>
                 <div class="nav-user">
                     <div id="nav-user-profile"></div>
@@ -181,6 +181,32 @@
                                 </p>
                             </div>
                         </div>
+                    </div>
+
+                    <div class="profile-settings">
+                        <h3>基本情報</h3>
+                        <div class="form-group">
+                            <label for="profile-username">ユーザー名</label>
+                            <input type="text" id="profile-username" class="form-input" maxlength="20">
+                        </div>
+                        <div class="form-group">
+                            <label for="profile-email">メールアドレス</label>
+                            <input type="email" id="profile-email" class="form-input">
+                        </div>
+                        <button id="update-profile-btn" class="btn primary-btn">プロフィールを更新</button>
+                    </div>
+
+                    <div class="profile-settings">
+                        <h3>パスワード変更</h3>
+                        <div class="form-group">
+                            <label for="new-password">新しいパスワード</label>
+                            <input type="password" id="new-password" class="form-input" minlength="6">
+                        </div>
+                        <div class="form-group">
+                            <label for="confirm-password">パスワード確認</label>
+                            <input type="password" id="confirm-password" class="form-input" minlength="6">
+                        </div>
+                        <button id="update-password-btn" class="btn secondary-btn">パスワードを変更</button>
                     </div>
                 </div>
             </div>

--- a/front/js/app.js
+++ b/front/js/app.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
         setupDiaryListeners();
         setupFriendListeners();
         setupNotificationListeners();
+        setupProfileListeners();
         
         console.log('=== アプリケーション初期化完了 ===');
     } catch (error) {
@@ -52,6 +53,12 @@ function setupNavListeners() {
     document.getElementById('nav-notifications').addEventListener('click', () => {
         switchContent('notifications');
         loadNotifications();
+    });
+    
+    // プロフィールリンク
+    document.getElementById('nav-profile').addEventListener('click', () => {
+        switchContent('profile');
+        initializeProfileScreen();
     });
 }
 

--- a/front/js/auth.js
+++ b/front/js/auth.js
@@ -12,6 +12,12 @@ function checkAuth() {
         document.getElementById('user-name').textContent = currentUser?.username || '';
         document.getElementById('streak-number').textContent = currentUser?.streak_count || '0';
         currentUserId = currentUser?.id || null;
+        
+        // プロフィール画像を更新
+        if (typeof updateNavProfileImage === 'function') {
+            updateNavProfileImage();
+        }
+        
         loadInitialData();
         if (typeof loadFriends === 'function') loadFriends();
         if (typeof loadFriendRequests === 'function') loadFriendRequests();
@@ -133,6 +139,11 @@ async function fetchUserInfo() {
         // ユーザー名とストリーク数を表示
         document.getElementById('user-name').textContent = userData.username;
         document.getElementById('streak-number').textContent = userData.streak_count;
+        
+        // プロフィール画像を更新
+        if (typeof updateNavProfileImage === 'function') {
+            updateNavProfileImage();
+        }
         
     } catch (error) {
         console.error('Error fetching user info:', error);

--- a/front/js/diary.js
+++ b/front/js/diary.js
@@ -44,6 +44,7 @@ async function loadDiaryFeed() {
             console.log(`フレンド日記 ${index + 1}:`, diary);
             console.log(`フレンド日記 ${index + 1} のユーザー情報:`, diary.user);
             console.log(`フレンド日記 ${index + 1} のユーザー名:`, diary.user?.username);
+            console.log(`フレンド日記 ${index + 1} のプロフィール画像:`, diary.user?.profile_image_url);
             const card = createDiaryCard(diary);
             feedContainer.appendChild(card);
         });

--- a/front/js/diary.js
+++ b/front/js/diary.js
@@ -122,9 +122,13 @@ function createDiaryCard(diary) {
     // カード内容
     let cardContent = '';
     
-    // フレンドの日記の場合はユーザー名をタイトルの上に表示
+    // フレンドの日記の場合はユーザー名とプロフィール画像をタイトルの上に表示
     if (isFriendDiary) {
-        cardContent += `<div class="diary-friend-name">👤 ${authorText}</div>`;
+        const friendProfileImage = createProfileImage(diary.user, 'small');
+        cardContent += `<div class="diary-friend-info">
+            <div class="diary-friend-avatar">${friendProfileImage.innerHTML}</div>
+            <div class="diary-friend-name">${authorText}</div>
+        </div>`;
     }
     
     cardContent += `

--- a/front/js/friends.js
+++ b/front/js/friends.js
@@ -162,6 +162,9 @@ function showFriendDiariesModal(diaries, friendId, friendName) {
         width: 90%;
     `;
     
+    // メインCSSのスタイルを継承するためのクラスを追加
+    modalContent.className = 'friend-diaries-modal-content';
+    
     modalContent.innerHTML = `
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
             <h2>${friendName}の日記</h2>
@@ -231,8 +234,12 @@ function createDiaryCard(diary) {
     
     let cardHTML = '';
     
-    // フレンドのユーザー名をタイトルの上に表示
-    cardHTML += `<div style="color: #6a5acd; font-weight: 600; font-size: 0.9em; margin-bottom: 8px; padding: 4px 8px; background-color: rgba(106, 90, 205, 0.1); border-radius: 4px; display: inline-block;">👤 ${authorName}</div>`;
+    // フレンドのユーザー名とプロフィール画像をタイトルの上に表示
+    const friendProfileImage = createProfileImage(diary.user, 'small');
+    cardHTML += `<div class="diary-friend-info">
+        <div class="diary-friend-avatar">${friendProfileImage.innerHTML}</div>
+        <div class="diary-friend-name">${authorName}</div>
+    </div>`;
     
     cardHTML += `
         <div style="margin-bottom: 10px;">

--- a/front/js/profile.js
+++ b/front/js/profile.js
@@ -1,0 +1,240 @@
+// プロフィール関連の処理
+
+// Cropper.jsインスタンス
+let cropper = null;
+
+// プロフィール画像を生成する関数
+function createProfileImage(user, size = '') {
+    const container = document.createElement('div');
+    
+    if (user.profile_image_url) {
+        const img = document.createElement('img');
+        img.src = user.profile_image_url;
+        img.className = `profile-image ${size}`;
+        img.alt = `${user.username}のプロフィール画像`;
+        container.appendChild(img);
+    } else {
+        const placeholder = document.createElement('div');
+        placeholder.className = `profile-image-placeholder ${size}`;
+        placeholder.textContent = user.username.charAt(0).toUpperCase();
+        container.appendChild(placeholder);
+    }
+    
+    return container;
+}
+
+// ナビゲーションバーのプロフィール画像を更新
+function updateNavProfileImage() {
+    const navProfileContainer = document.getElementById('nav-user-profile');
+    if (currentUser && navProfileContainer) {
+        navProfileContainer.innerHTML = '';
+        const profileImage = createProfileImage(currentUser, 'small');
+        navProfileContainer.appendChild(profileImage);
+    }
+}
+
+// 現在のプロフィール画像を表示
+function displayCurrentProfileImage() {
+    const container = document.getElementById('current-profile-image');
+    if (currentUser && container) {
+        container.innerHTML = '';
+        const profileImage = createProfileImage(currentUser, 'large');
+        container.appendChild(profileImage);
+    }
+}
+
+// 画像ファイルをBase64に変換
+function fileToBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
+// クロップモーダルを開く
+function openCropModal(file) {
+    const modal = document.getElementById('crop-modal');
+    const cropImage = document.getElementById('crop-image');
+    const previewContainer = document.getElementById('crop-preview-container');
+    
+    // モーダルを表示
+    modal.classList.remove('hidden');
+    
+    // ファイルを画像要素に設定
+    const reader = new FileReader();
+    reader.onload = function(e) {
+        cropImage.src = e.target.result;
+        
+        // 既存のcropperがあれば破棄
+        if (cropper) {
+            cropper.destroy();
+        }
+        
+        // Cropper.jsを初期化
+        cropper = new Cropper(cropImage, {
+            aspectRatio: 1, // 正方形
+            viewMode: 2,
+            dragMode: 'move',
+            autoCropArea: 1,
+            restore: false,
+            guides: false,
+            center: false,
+            highlight: false,
+            cropBoxMovable: false,
+            cropBoxResizable: true,
+            toggleDragModeOnDblclick: false,
+            preview: previewContainer,
+            ready: function() {
+                // クロッパーが準備完了したときの処理
+                console.log('Cropper is ready');
+            }
+        });
+    };
+    
+    reader.readAsDataURL(file);
+}
+
+// クロップモーダルを閉じる
+function closeCropModal() {
+    const modal = document.getElementById('crop-modal');
+    modal.classList.add('hidden');
+    
+    // Cropperインスタンスを破棄
+    if (cropper) {
+        cropper.destroy();
+        cropper = null;
+    }
+    
+    // 画像をクリア
+    const cropImage = document.getElementById('crop-image');
+    cropImage.src = '';
+    
+    // ファイル入力をクリア
+    const fileInput = document.getElementById('profile-image-input');
+    fileInput.value = '';
+}
+
+// クロップを適用してプロフィール画像を更新
+async function applyCrop() {
+    if (!cropper) {
+        alert('画像が読み込まれていません。');
+        return;
+    }
+    
+    try {
+        // クロップされた画像をcanvasとして取得
+        const canvas = cropper.getCroppedCanvas({
+            width: 200,
+            height: 200,
+            imageSmoothingEnabled: true,
+            imageSmoothingQuality: 'high'
+        });
+        
+        // canvasをBase64に変換
+        const croppedImageUrl = canvas.toDataURL('image/jpeg', 0.8);
+        
+        // プロフィール画像を更新
+        await updateProfileImage(croppedImageUrl);
+        
+        // モーダルを閉じる
+        closeCropModal();
+        
+    } catch (error) {
+        console.error('Error applying crop:', error);
+        alert('画像のクロップに失敗しました。');
+    }
+}
+
+// プロフィール画像を更新
+async function updateProfileImage(imageUrl) {
+    try {
+        console.log('Updating profile image...', { imageUrl: imageUrl.substring(0, 50) + '...' });
+        
+        const response = await fetch(`${API_BASE_URL}/users/me/profile-image`, {
+            method: 'PUT',
+            headers: {
+                'Authorization': `Bearer ${authToken}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                profile_image_url: imageUrl
+            })
+        });
+
+        console.log('Response status:', response.status);
+        
+        if (!response.ok) {
+            const errorText = await response.text();
+            console.error('Error response:', errorText);
+            throw new Error(`プロフィール画像の更新に失敗しました (${response.status}): ${errorText}`);
+        }
+
+        const updatedUser = await response.json();
+        console.log('Updated user:', updatedUser);
+        
+        // 現在のユーザー情報を更新
+        currentUser.profile_image_url = updatedUser.profile_image_url;
+        localStorage.setItem('currentUser', JSON.stringify(currentUser));
+        
+        // 画面の表示を更新
+        displayCurrentProfileImage();
+        updateNavProfileImage();
+        
+        alert('プロフィール画像を更新しました！');
+        
+    } catch (error) {
+        console.error('Error updating profile image:', error);
+        alert('プロフィール画像の更新に失敗しました: ' + error.message);
+    }
+}
+
+// ファイル選択時の処理（クロップモーダル対応版）
+async function handleImageUpload(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    // ファイルサイズチェック（5MB制限）
+    if (file.size > 5 * 1024 * 1024) {
+        alert('ファイルサイズが大きすぎます。5MB以下の画像を選択してください。');
+        return;
+    }
+
+    // ファイル形式チェック
+    if (!file.type.startsWith('image/')) {
+        alert('画像ファイルを選択してください。');
+        return;
+    }
+
+    // クロップモーダルを開く
+    openCropModal(file);
+}
+
+// プロフィール関連のイベントリスナーを設定
+function setupProfileListeners() {
+    // プロフィール画像アップロードボタン
+    document.getElementById('profile-image-upload-btn').addEventListener('click', () => {
+        document.getElementById('profile-image-input').click();
+    });
+
+    // ファイル選択
+    document.getElementById('profile-image-input').addEventListener('change', handleImageUpload);
+    
+    // クロップモーダルのイベントリスナー
+    document.getElementById('crop-modal-close').addEventListener('click', closeCropModal);
+    document.getElementById('crop-cancel-btn').addEventListener('click', closeCropModal);
+    document.getElementById('crop-apply-btn').addEventListener('click', applyCrop);
+    
+    // モーダル背景クリックで閉じる
+    document.getElementById('crop-modal').addEventListener('click', (e) => {
+        if (e.target.id === 'crop-modal') {
+            closeCropModal();
+        }
+    });
+}
+
+// プロフィール画面の初期化
+function initializeProfileScreen() {
+    displayCurrentProfileImage();
+}


### PR DESCRIPTION
## feat: ユーザープロフィール画像機能の実装

### 概要

このプルリクエストでは、ユーザーが自分のプロフィール画像を設定・表示できる機能を実装しました。画像のクロップ機能、Base64での保存、フレンド日記での表示など、包括的なプロフィール画像システムを構築しています。

### 主な変更点

#### ✨ 新機能

**1. プロフィール画像管理システム**
- 画像アップロード機能（ファイル選択UI）
- Cropper.jsを使った画像クロップ・編集機能
- 200x200ピクセルでの最適化とBase64エンコード保存
- プロフィール画像の更新・削除機能

**2. 統一的なプロフィール画像表示**
- ナビゲーションバーでのプロフィール画像表示
- フレンド日記カードでの作者アイコン表示
- プロフィール設定画面での現在画像プレビュー
- 画像未設定時のイニシャル表示（フォールバック）

**3. フレンド日記UI改善**
- 日記カードに作者のプロフィール画像と名前を表示
- 視覚的にフレンドの日記を識別しやすく改善
- レスポンシブ対応の丸形アイコンデザイン

#### 🔧 技術的実装

**バックエンド:**
- `User`モデルに`profile_image_url`カラムを追加
- `UserInfo`スキーマでプロフィール画像情報をAPIレスポンスに含める
- `ProfileImageUpdate`スキーマによる画像更新API
- `joinedload`を使ったユーザー情報の効率的な取得

**フロントエンド:**
- Cropper.jsライブラリの統合
- モーダルベースの画像編集UI
- Base64画像データの処理とAPI送信
- 統一的なプロフィール画像表示コンポーネント

### 関連ファイル

#### バックエンド
- `back/app/models/user.py` (profile_image_urlカラム追加)
- `back/app/schemas/user.py` (ProfileImageUpdateスキーマ追加)
- `back/app/schemas/diary.py` (UserInfoスキーマにprofile_image_url追加)
- `back/app/api/routes/user.py` (プロフィール画像更新エンドポイント)
- `back/app/crud/user.py` (プロフィール画像更新関数)
- `back/app/crud/diary.py` (joinedloadによるユーザー情報取得)

#### フロントエンド
- `front/js/profile.js` (プロフィール画像管理機能)
- `front/js/diary.js` (フレンド日記でのプロフィール画像表示)
- `front/js/friends.js` (フレンド一覧でのプロフィール画像表示)
- `front/js/auth.js` (認証時のプロフィール画像更新)
- `front/js/app.js` (ナビゲーションバーでのプロフィール画像表示)
- `front/index.html` (プロフィール設定UI、クロップモーダル)
- `front/css/styles.css` (プロフィール画像関連スタイル)

### データベース設計

```sql
-- usersテーブルに追加されたカラム
ALTER TABLE users ADD COLUMN profile_image_url TEXT;